### PR TITLE
feat: add autofix.yml

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,24 @@
+name: autofix.ci
+
+on:
+  workflow_call:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: ./.github/actions/python-poetry-env
+      
+      # Fix lint errors using pre-commit
+      - name: Run pre-commit auto-fix
+        run: poetry run pre-commit run --all-files
+      
+      - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,24 +1,26 @@
 name: autofix.ci
 
 on:
-  workflow_call:
   pull_request:
-  push:
-    branches: [ "main" ]
+    paths:
+      - "**/*.py"
 
-permissions:
-  contents: read
+env:
+  POETRY_VERSION: "1.8.4"
 
 jobs:
-  autofix:
+  lint:
+    name: Run Ruff Check and Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       
       - uses: ./.github/actions/python-poetry-env
       
-      # Fix lint errors using pre-commit
-      - name: Run pre-commit auto-fix
-        run: poetry run pre-commit run --all-files
+      - name: Run Ruff Check with auto-fix
+        run: poetry run ruff check --fix-only .
       
-      - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c 
+      - name: Run Ruff Format
+        run: poetry run ruff format .
+      
+      - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically fix linting errors in the codebase. The workflow is named `autofix.ci` and is triggered on pull requests and pushes to the `main` branch.

New GitHub Actions workflow:

* [`.github/workflows/autofix.yml`](diffhunk://#diff-89b476612e9731e1d69620da47f8939f627c347fa6575984daa6b71a4077dab4R1-R24): Added a new workflow named `autofix.ci` that runs on `ubuntu-latest`, checks out the code, sets up the Python environment using `poetry`, and runs `pre-commit` to fix lint errors.