### PR TITLE
fix: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ Refer to the Contributing Guidelines for more details.
 
 ## :warning: License
 
-This project is licensed under the MIT License. See the LICENSE file for details.
+This project is licensed under the Apache 2.0 License. See the LICENSE file for details [here](https://github.com/Qentora/quoptuna?tab=Apache-2.0-1-ov-file).
 
 ## :gem: Acknowledgments
 
-This project was generated using the [wolt-python-package-cookiecutter](https://github.com/woltapp/wolt-python-package-cookiecutter) template.
+This project was generated using the [wolt-python-package-cookiecutter](https://github.com/woltapp/wolt-python-package-cookiecutter) template. 
+
+This project includes code from the [qml-benchmarks project by XanaduAI](https://github.com/XanaduAI/qml-benchmarks). Licensed under the Apache License, Version 2.0.
 
 ---


### PR DESCRIPTION
This pull request includes a change to the `README.md` file to update the licensing information and add an acknowledgment for included code from another project.

Licensing and acknowledgment updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R158): Changed the project license from MIT License to Apache 2.0 License and updated the link to the LICENSE file.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R158): Added acknowledgment for code included from the `qml-benchmarks` project by XanaduAI, specifying that it is licensed under the Apache License, Version 2.0.