### PR TITLE
feat: Add recent activity section with Repography badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,13 @@ This project was generated using the [wolt-python-package-cookiecutter](https://
 This project includes code from the [qml-benchmarks project by XanaduAI](https://github.com/XanaduAI/qml-benchmarks). Licensed under the Apache License, Version 2.0.
 
 ---
+
+## [![Repography logo](https://images.repography.com/logo.svg)](https://repography.com) / Recent activity [![Time period](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_badge.svg)](https://repography.com)
+[![Timeline graph](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_timeline.svg)](https://github.com/Qentora/quoptuna/commits)
+[![Issue status graph](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_issues.svg)](https://github.com/Qentora/quoptuna/issues)
+[![Pull request status graph](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_prs.svg)](https://github.com/Qentora/quoptuna/pulls)
+[![Trending topics](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_words.svg)](https://github.com/Qentora/quoptuna/commits)
+[![Top contributors](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_users.svg)](https://github.com/Qentora/quoptuna/graphs/contributors)
+[![Activity map](https://images.repography.com/61358072/Qentora/quoptuna/recent-activity/NFJ5verQB-dv9RS0RuDOgSE84SRTHP39DKgPw9dAbEI/BGB39P4WjaaHESiizHx0odYYf_6ZBBoXmK4Gh8qIAD4_map.svg)](https://github.com/Qentora/quoptuna/commits)
+
+


### PR DESCRIPTION
This pull request adds a new section to the `README.md` that displays recent repository activity using Repography visualizations. This enhancement provides quick insights into project trends, issue and pull request status, contributor activity, and other metrics.

Repository activity and visualization:

* Added a "Recent activity" section to `README.md` featuring Repography graphs and badges for timeline, issues, pull requests, trending topics, top contributors, and activity map.

---
## EntelligenceAI PR Summary 
 This PR enhances the README.md with Repography integration to display project activity metrics.
- Added six embedded SVG visualizations (activity timeline, issue status, PR status, trending topics, top contributors, activity map)
- Each visualization links to its corresponding GitHub page
- Improves project transparency without affecting functional code 

