### PR TITLE
feat: Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![License](https://img.shields.io/github/license/Qentora/quoptuna.svg)](https://github.com/Qentora/quoptuna/blob/master/LICENSE)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Qentora/quoptuna)
+
 </div>
 
 ---


### PR DESCRIPTION
This pull request adds a new badge to the `README.md` to highlight integration with DeepWiki. This change visually indicates the project's presence on DeepWiki and provides a direct link for users.

* Added a DeepWiki badge to the top of the `README.md`, linking to the project's DeepWiki page.

---
## EntelligenceAI PR Summary 
 This PR adds a DeepWiki badge to the README.md file to improve project discoverability.
- Added badge in the README.md badges section
- Included link to the project's DeepWiki page at https://deepwiki.com/Qentora/quoptuna
- Enhanced documentation with additional project information resource 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a DeepWiki badge/link to the README for quick access to extended project knowledge.
  * Improves discoverability of documentation resources directly from the repository landing page.
  * No changes to application behavior, interfaces, or APIs.
  * Intended to streamline onboarding and reference by providing a clear entry point to DeepWiki content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->