### PR TITLE
Fix MkDocs build issues and add local testing script

### DIFF
--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -1,3 +1,27 @@
-# API documentation
+# API Documentation
 
-:::quoptuna
+## Main API
+
+::: quoptuna.XAI
+    options:
+      members: true
+      show_root_heading: true
+
+::: quoptuna.XAIConfig
+    options:
+      members: true
+      show_root_heading: true
+
+::: quoptuna.Optimizer
+    options:
+      members: true
+      show_root_heading: true
+
+::: quoptuna.DataPreparation
+    options:
+      members: true
+      show_root_heading: true
+
+::: quoptuna.create_model
+    options:
+      show_root_heading: true

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -273,7 +273,7 @@ Advanced users can integrate custom models by:
 
 - Explore the [API Documentation](api_reference.md) for programmatic usage
 - Check out [Examples](examples.md) for common use cases
-- Review [Development Guide](development.md) for contributing
+- Contribute on [GitHub](https://github.com/Qentora/quoptuna)
 
 ## Support
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,11 +102,11 @@ plugins:
           options:
             # show_signature_annotations: true
             show_source: true
-            show_submodules: true
+            show_submodules: false
             docstring_options:
               ignore_init_summary: false
             docstring_section_style: spacy
-            filters: ["!^_"]
+            filters: ["!^_", "!^pennylane_models"]
             inherited_members: true
             merge_init_into_class: true
             parameter_headings: true
@@ -115,7 +115,7 @@ plugins:
             scoped_crossrefs: true
             separate_signature: true
             show_bases: true
-            show_inheritance_diagram: true
+            show_inheritance_diagram: false
             show_root_heading: true
             show_root_full_path: false
             show_signature_annotations: true
@@ -124,7 +124,7 @@ plugins:
             signature_crossrefs: true
             summary: true
             unwrap_annotated: true
-  - social
+  # - social  # Disabled to avoid font loading issues in CI
   - tags
   - offline
   - glightbox:

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -20,34 +20,28 @@ class Optimizer:
         data: Optional[dict] = None,  # noqa: FA100
         study_name: str = "",
     ):
-        """
-
-        Initialize the Optimizer class.
+        """Initialize the Optimizer class.
 
         Args:
-            db_name (str): The name of the database to be used for storing optimization results.
-            dataset_name (str, optional): The name of the dataset.
-            If provided, the data will be loaded from a CSV file located in the 'notebook'
-            directory.Defaults to an empty string.
-            data (Optional[dict], optional): A dictionary containing training and testing data.
-            If not provided, an empty dictionary will be used.
-            Expected keys are 'train_x', 'test_x', 'train_y', and 'test_y'.
-            study_name (str, optional): The name of the study for Optuna.
-            Defaults to an empty string.
+            db_name: The name of the database to be used for storing optimization results.
+            dataset_name: The name of the dataset. If provided, the data will be loaded from a
+                CSV file located in the 'notebook' directory. Defaults to an empty string.
+            data: A dictionary containing training and testing data. If not provided, an empty
+                dictionary will be used. Expected keys are 'train_x', 'test_x', 'train_y', and 'test_y'.
+            study_name: The name of the study for Optuna. Defaults to an empty string.
 
         Attributes:
-            db_name (str): The name of the database.
-            dataset_name (str): The name of the dataset.
-            data_path (str): The path to the dataset CSV file or an empty string
-            if no dataset name is provided.
-            data (dict): The data dictionary containing training and testing data.
-            train_x (Optional[np.ndarray]): The training features.
-            test_x (Optional[np.ndarray]): The testing features.
-            train_y (Optional[np.ndarray]): The training labels.
-            test_y (Optional[np.ndarray]): The testing labels.
-            storage_location (str): The storage location for the Optuna study.
-            study_name (str): The name of the Optuna study.
-            study (Optional[Study]): The Optuna study object.
+            db_name: The name of the database.
+            dataset_name: The name of the dataset.
+            data_path: The path to the dataset CSV file or an empty string if no dataset name is provided.
+            data: The data dictionary containing training and testing data.
+            train_x: The training features.
+            test_x: The testing features.
+            train_y: The training labels.
+            test_y: The testing labels.
+            storage_location: The storage location for the Optuna study.
+            study_name: The name of the Optuna study.
+            study: The Optuna study object.
         """
         self.db_name = db_name
         self.dataset_name = dataset_name

--- a/test-docs-build.sh
+++ b/test-docs-build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Local MkDocs Build Test Script
+# This script mimics the CI build process for testing documentation locally
+
+set -e  # Exit on error
+
+echo "=========================================="
+echo "Testing MkDocs Build Locally"
+echo "=========================================="
+echo ""
+
+# Check if Python is installed
+if ! command -v python3 &> /dev/null; then
+    echo "Error: Python 3 is not installed"
+    exit 1
+fi
+
+echo "Step 1: Creating virtual environment..."
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+    echo "✓ Virtual environment created"
+else
+    echo "✓ Virtual environment already exists"
+fi
+
+echo ""
+echo "Step 2: Activating virtual environment..."
+source venv/bin/activate
+echo "✓ Virtual environment activated"
+
+echo ""
+echo "Step 3: Upgrading pip..."
+python -m pip install --upgrade pip -q
+echo "✓ pip upgraded"
+
+echo ""
+echo "Step 4: Installing documentation dependencies..."
+pip install -q mkdocs-material mkdocs-autorefs mkdocstrings[python] mkdocs-glightbox pillow cairosvg
+echo "✓ Dependencies installed"
+
+echo ""
+echo "Step 5: Building documentation with MkDocs..."
+echo "Running: mkdocs build --strict --verbose"
+echo "=========================================="
+mkdocs build --strict --verbose
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "=========================================="
+    echo "✓ SUCCESS: Documentation built successfully!"
+    echo "=========================================="
+    echo ""
+    echo "To view the built documentation:"
+    echo "  1. Run: mkdocs serve"
+    echo "  2. Open: http://127.0.0.1:8000"
+    echo ""
+    echo "Or open the built site directly:"
+    echo "  file://$(pwd)/site/index.html"
+    echo ""
+else
+    echo ""
+    echo "=========================================="
+    echo "✗ FAILED: Documentation build failed"
+    echo "=========================================="
+    exit 1
+fi


### PR DESCRIPTION
Changes:
- Modified api_docs.md to document specific public API classes instead of entire package This prevents griffe from loading problematic pennylane_models directory
- Updated mkdocs.yml:
  * Disabled social plugin to avoid font loading issues in CI
  * Set show_submodules to false to prevent deep module traversal
  * Disabled show_inheritance_diagram to reduce complexity
- Fixed broken link in user_guide.md (development.md -> GitHub link)
- Fixed malformed docstring in optimizer.py that was causing griffe parsing warnings
- Added test-docs-build.sh script for local documentation testing

The build now passes with --strict mode enabled.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
