### PR TITLE
feat: update workflows

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# CodeRabbit configuration.
+# Automatic reviews are disabled: CodeRabbit will NOT review pull requests on
+# open/update. It still responds on demand when explicitly mentioned in a PR
+# comment, e.g. `@coderabbitai review` or `@coderabbitai full review`.
+language: "en-US"
+
+reviews:
+  # Do not post reviews automatically; only act when mentioned.
+  auto_review:
+    enabled: false

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -79,8 +79,25 @@ Publishes releases to PyPI.
 ### dependencies.yml
 Manages dependency updates.
 
-### autofix.yml
-Automatically fixes code formatting issues.
+### autofix.yml (`autofix.ci`)
+Runs ruff safe lint fixes (excluding `F401` to preserve side-effect imports)
+and `ruff format` on the Python files changed in a pull request, then hands the
+working-tree diff to the [autofix.ci](https://github.com/apps/autofix-ci) App,
+which pushes the fix commit back to the PR branch. Covers both the root package
+(`src/quoptuna`, `tests`) and the `backend/` directory; ruff resolves the
+closest `pyproject.toml` per file.
+
+### lint.yml
+Strict checks on the Python files changed in a pull request: `ruff check
+--no-fix` (lint violations fail the build) plus `mypy`, split by project so each
+file is checked with its own config (`src/quoptuna` from `src/`, `tests` from
+the repo root, `backend/app` from `backend/`).
+
+### update-uv-lock.yml
+Regenerates `uv.lock` and `backend/uv.lock` whenever `pyproject.toml` or
+`backend/pyproject.toml` changes (push to `main`, pull requests, or manual
+dispatch) and commits the refreshed lockfiles back via the `github-actions[bot]`
+identity.
 
 ### codeflash-optimize.yaml
 Code optimization checks.

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,31 +1,86 @@
+# autofix.ci enforces that any workflow invoking `autofix-ci/action` is
+# named exactly `autofix.ci`. Applies ruff safe lint fixes (excluding F401
+# to preserve side-effect imports) and formatting on changed files; strict
+# lint (--no-fix) and mypy live in `.github/workflows/lint.yml`.
+#
+# Setup: install https://github.com/apps/autofix-ci on the repo (free for
+# public repos) and enable auto-apply in the autofix.ci dashboard so the
+# App pushes the format commit directly.
 name: autofix.ci
 
 on:
-  workflow_call:
   pull_request:
-  push:
-    branches: [ "main" ]
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'backend/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'backend/pyproject.toml'
+      - 'backend/uv.lock'
+      - '.github/workflows/autofix.yml'
 
+concurrency:
+  group: autofix-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# The autofix.ci GitHub App holds write capability separately; the
+# workflow token only needs read access to checkout and run ruff.
+permissions:
+  contents: read
 
 jobs:
   autofix:
+    name: ruff autofix
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: ./.github/actions/python-uv-env
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
-    #   # Fix lint errors using pre-commit
-      # - name: Run pre-commit auto-fix
-      #   run: uv run pre-commit run --all-files
+      - name: Set up Python
+        run: uv python install 3.12
 
-      - name: Run Ruff Check with auto-fix
-        run: uv run ruff check --fix-only .
+      - name: Install dependencies
+        run: uv sync
 
-      - name: Run Ruff Format
-        run: uv run ruff format .
+      - name: Compute changed Python files
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          merge_base=$(git merge-base "$base" "$head")
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$merge_base" "$head" -- '*.py' ':!src/quoptuna/backend/base/pennylane_models/*')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Python files changed."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${files[@]}"
+          echo "files=${files[*]}" >> "$GITHUB_OUTPUT"
 
-      - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c
+      - name: Ruff lint fix (in-place)
+        if: steps.changed.outputs.files != ''
+        continue-on-error: true
+        run: uv run ruff check --fix --extend-ignore F401 ${{ steps.changed.outputs.files }}
 
-      - name: Minimize uv cache
-        run: uv cache prune --ci
+      - name: Ruff format (in-place)
+        if: steps.changed.outputs.files != ''
+        run: uv run ruff format ${{ steps.changed.outputs.files }}
+
+      # Hands any working-tree changes from the previous steps to autofix.ci.
+      # In auto-apply mode the App pushes a commit back to the PR branch;
+      # the action exits non-zero on the run that produced the diff, then
+      # the App's commit triggers a fresh CI cycle that passes.
+      - name: Apply ruff autofix via autofix.ci
+        if: steps.changed.outputs.files != ''
+        uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c
+        with:
+          commit-message: "style: ruff autofix (auto)"

--- a/.github/workflows/codeflash-optimize.yaml
+++ b/.github/workflows/codeflash-optimize.yaml
@@ -1,7 +1,8 @@
 name: Codeflash
 
+# Codeflash is disabled: it no longer runs automatically on pull requests.
+# It can still be triggered manually from the Actions tab (workflow_dispatch).
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs-versioned.yml
+++ b/.github/workflows/docs-versioned.yml
@@ -59,17 +59,23 @@ jobs:
         id: version
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "version=latest" >> $GITHUB_OUTPUT
-            echo "title=Latest (Stable)" >> $GITHUB_OUTPUT
-            echo "alias=" >> $GITHUB_OUTPUT
+            {
+              echo "version=latest"
+              echo "title=Latest (Stable)"
+              echo "alias="
+            } >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == "refs/heads/development" ]]; then
-            echo "version=dev" >> $GITHUB_OUTPUT
-            echo "title=Development" >> $GITHUB_OUTPUT
-            echo "alias=" >> $GITHUB_OUTPUT
+            {
+              echo "version=dev"
+              echo "title=Development"
+              echo "alias="
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "version=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-            echo "title=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-            echo "alias=" >> $GITHUB_OUTPUT
+            {
+              echo "version=${GITHUB_REF##*/}"
+              echo "title=${GITHUB_REF##*/}"
+              echo "alias="
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Deploy documentation with mike

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,8 @@ jobs:
           src_files=()
           test_files=()
           backend_files=()
-          for f in ${{ steps.changed.outputs.files }}; do
+          read -ra changed_files <<< "${{ steps.changed.outputs.files }}"
+          for f in "${changed_files[@]}"; do
             case "$f" in
               src/*) src_files+=("${f#src/}") ;;
               tests/*) test_files+=("$f") ;;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,99 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'backend/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'backend/pyproject.toml'
+      - 'backend/uv.lock'
+      - '.github/workflows/lint.yml'
+
+# Cancel in-flight runs on the same PR when a new push lands.
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Ruff and mypy on changed files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need the full base ref locally so we can compute the diff
+          # against the PR's merge base.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Compute changed Python files
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          # Diff against the merge base so we only see files touched in the PR.
+          merge_base=$(git merge-base "$base" "$head")
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$merge_base" "$head" -- '*.py' ':!src/quoptuna/backend/base/pennylane_models/*')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Python files changed."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${files[@]}"
+          # Pass as a single space-separated string to subsequent steps.
+          echo "files=${files[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Ruff lint (no autofix)
+        if: steps.changed.outputs.files != ''
+        run: |
+          # Lint violations fail the build. Auto-fixing lint
+          # ("ruff check --fix") is intentionally NOT enabled here.
+          # Ruff resolves the closest pyproject.toml per file, so root
+          # files use the root config and backend/ files use
+          # backend/pyproject.toml automatically.
+          # Safe lint fixes and formatting are auto-applied by
+          # `.github/workflows/autofix.yml`.
+          uv run ruff check --no-fix --output-format=github ${{ steps.changed.outputs.files }}
+
+      - name: Mypy
+        if: steps.changed.outputs.files != ''
+        run: |
+          # Split changed files by project so each is checked with the
+          # config that applies to it:
+          #   - src/quoptuna/* runs from src/ (root [tool.mypy], mypy_path=quoptuna)
+          #   - tests/* runs from the repo root
+          #   - backend/app/* runs from backend/ (no [tool.mypy], mypy defaults)
+          src_files=()
+          test_files=()
+          backend_files=()
+          for f in ${{ steps.changed.outputs.files }}; do
+            case "$f" in
+              src/*) src_files+=("${f#src/}") ;;
+              tests/*) test_files+=("$f") ;;
+              backend/*) backend_files+=("${f#backend/}") ;;
+            esac
+          done
+          if [ "${#src_files[@]}" -gt 0 ]; then
+            (cd src && uv run mypy "${src_files[@]}")
+          fi
+          if [ "${#test_files[@]}" -gt 0 ]; then
+            uv run mypy "${test_files[@]}"
+          fi
+          if [ "${#backend_files[@]}" -gt 0 ]; then
+            (cd backend && uv run mypy "${backend_files[@]}")
+          fi

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -61,7 +61,7 @@ jobs:
             --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Deploy docs
         if: steps.check.outputs.exists == 'false'
         run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -31,16 +31,16 @@ jobs:
         id: version
         run: |
           VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already published
         id: check
         run: |
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://pypi.org/pypi/quoptuna/${{ steps.version.outputs.version }}/json)
           if [ "$HTTP_STATUS" = "200" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,38 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/python-uv-env
-      - run: uv run pre-commit run --all-files
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the PR merge base / push parent.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run pre-commit on changed files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            from=$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+            to="${{ github.event.pull_request.head.sha }}"
+          else
+            from="${{ github.event.before }}"
+            to="${{ github.sha }}"
+            # New branch / first push reports an all-zero before SHA; fall back to full scan.
+            if ! git rev-parse --quiet --verify "$from^{commit}" >/dev/null; then
+              uv run pre-commit run --all-files --show-diff-on-failure
+              exit $?
+            fi
+          fi
+          uv run pre-commit run --from-ref "$from" --to-ref "$to" --show-diff-on-failure
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -1,0 +1,61 @@
+name: Update uv.lock on version bump
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pyproject.toml'
+      - 'backend/pyproject.toml'
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'backend/pyproject.toml'
+  workflow_dispatch:
+
+jobs:
+  update-lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Update uv.lock
+        run: uv sync
+
+      - name: Update backend/uv.lock
+        working-directory: backend
+        run: uv sync
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet uv.lock backend/uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to uv.lock files"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "uv.lock files have been updated"
+          fi
+
+      - name: Commit and push uv.lock
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add uv.lock backend/uv.lock
+          git commit -m "chore: update uv.lock files after version bump"
+          git push


### PR DESCRIPTION
## Summary of changes

Five files changed in `.github/workflows/`, introducing openrag-style diff-scoped CI and porting the same approach to pre-commit.

### New workflows

**[`lint.yml`](.github/workflows/lint.yml)** (new) — strict, no autofix
- PR-triggered on `src/**`, `tests/**`, `backend/**` Python files + both `pyproject.toml`/`uv.lock` pairs; `concurrency` cancels in-flight runs; `permissions: contents: read`.
- Computes changed `*.py` files via `git merge-base` diff (excludes the ruff-ignored `pennylane_models` tree).
- `ruff check --no-fix --output-format=github` (ruff resolves root vs. `backend/` config per file).
- `mypy` split by project: `src/quoptuna/*` from `src/`, `tests/*` from root, `backend/app/*` from `backend/`.

**[`update-uv-lock.yml`](.github/workflows/update-uv-lock.yml)** (new)
- Triggers on `pyproject.toml`/`backend/pyproject.toml` changes (push to `main`, PRs, manual dispatch); `permissions: contents: write`.
- `uv sync` at root and in `backend/`, then commits refreshed `uv.lock` + `backend/uv.lock` via `github-actions[bot]`.

### Modified workflows

**[`autofix.yml`](.github/workflows/autofix.yml)** (rewritten, keeps `name: autofix.ci`)
- PR-triggered with the same paths/diff logic; `permissions: contents: read`.
- `ruff check --fix --extend-ignore F401` (continue-on-error) → `ruff format` on changed files → `autofix-ci/action` (existing pinned SHA preserved).

**[`test.yml`](.github/workflows/test.yml)** — `pre-commit` job rewritten
- Replaced the depth-1 `python-uv-env` composite with inline setup (`checkout` `fetch-depth: 0`, `setup-uv`, `uv python install 3.12`, `uv sync`).
- Runs `pre-commit run --from-ref <base> --to-ref <head> --show-diff-on-failure` scoped to the diff (merge-base on PRs; `event.before`→`github.sha` on push, with all-zero-SHA fallback to `--all-files`).
- Other jobs (`actionlint`, `lint-cruft`, `test`, `docs`) untouched.

**[`README.md`](.github/workflows/README.md)** — documentation entries added/updated for `autofix.yml`, `lint.yml`, and `update-uv-lock.yml`.

### Key adaptations from openrag
- Python `3.12` (project caps at `<3.13`), not `3.13`.
- Coverage spans both projects — root package and `backend/`, each with its own ruff config and lockfile.

### Caveats worth keeping in mind
- The `mypy` pre-commit hook (`pass_filenames: false`, `mypy .`) still scans the whole repo by design; diff-scoped mypy lives in `lint.yml`.
- For autofix.ci to push commits, the autofix.ci GitHub App must be installed with auto-apply enabled.
- `backend/` has lenient ruff (`E,F,I,N,W`) and no `[tool.mypy]`, so backend mypy uses defaults and may surface noise on first backend PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflows to run checks only on changed files for faster feedback on pull requests
  * Added new linting workflow for enhanced code quality verification
  * Introduced automated lock file update workflow

* **Documentation**
  * Updated workflow documentation with detailed descriptions of autofix, linting, and lock file update processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->