### PR TITLE
feat: Enhance prunner with optimizer settings and stepper

### DIFF
--- a/docs/guides/samplers-and-pruning.md
+++ b/docs/guides/samplers-and-pruning.md
@@ -54,6 +54,23 @@ they always train to completion regardless of the pruner.
     exhaust every combination before `num_trials` — the study simply stops
     early.
 
+## Performance tuning
+
+The web UI's **Settings → Optimizer Performance** card (and the corresponding
+`POST /api/v1/optimize` fields) exposes three knobs that dominate trial
+wall-clock:
+
+- **`max_vmap`** (UI default 32): circuit evaluations vectorized per JAX call.
+  The historical value of 1 evaluates one sample at a time; on small tabular
+  datasets, 32 is severalfold faster. Must divide the batch size (32), so
+  valid values are 1/2/4/8/16/32.
+- **`max_steps`** (UI default 2000): training-step cap per trial (model
+  default 10,000). Trials that hit the cap unconverged are still scored.
+- **`convergence_interval`** (UI default 100): steps between flat-loss
+  convergence checks and pruning reports. Lower values let converged trials
+  exit sooner and give ASHA earlier decision points, at the cost of noisier
+  convergence estimates.
+
 ## Resource accounting
 
 Every completed or pruned trial records user attributes for

--- a/docs/guides/samplers-and-pruning.md
+++ b/docs/guides/samplers-and-pruning.md
@@ -26,9 +26,22 @@ Iterative (JAX-trained) quantum models report an intermediate value every
 other trials at the same rung and stops trials in the bottom fraction — they
 end in the `PRUNED` state (not `FAILED`) and never win `best_trial`.
 
+The pruner operates on the **report index** (1st, 2nd, 3rd report...), so
+`pruner_min_resource=1` means "a trial may be stopped after its first
+intermediate report". The `accuracy` metric is evaluated on a fixed validation
+subset (first 128 test rows) to bound the circuit cost of each report.
+
 Kernel models (IQPKernel, ProjectedQuantumKernel, QuantumKitchenSinks,
 SeparableKernelClassifier) and classical sklearn models have no training steps;
 they always train to completion regardless of the pruner.
+
+!!! note "Non-converging trials"
+    A trial that reaches `max_steps` without meeting the flat-loss convergence
+    criterion is **not** discarded: the partially-trained model is scored and
+    the trial completes with user attribute `converged: false`. To stop slow
+    trials from consuming the full default budget (10,000 steps), set
+    `max_steps` to a smaller cap — pruning alone cannot stop a trial whose
+    intermediate accuracy stays competitive while its loss keeps drifting.
 
 !!! warning "`neg_loss` caveat"
     `intermediate_metric="neg_loss"` costs zero extra circuit evaluations, but

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -23,9 +23,65 @@ import {
   saveAppSettings,
 } from '@/lib/appSettings';
 import { type ApiKeys, loadApiKeys, saveApiKeys } from '@/lib/settings';
-import { Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff, Minus, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
+
+/** Integer input with -/+ stepper buttons; value is kept as a string state. */
+function IntegerStepper({
+  id,
+  value,
+  onChange,
+  step,
+  min = 1,
+  placeholder,
+}: {
+  id: string;
+  value: string;
+  onChange: (next: string) => void;
+  step: number;
+  min?: number;
+  placeholder?: string;
+}) {
+  const nudge = (direction: 1 | -1) => {
+    const current = Math.floor(Number(value));
+    const base = Number.isFinite(current) && current >= min ? current : min;
+    onChange(String(Math.max(min, base + direction * step)));
+  };
+  return (
+    <div className="flex w-full max-w-xs items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        aria-label="Decrease"
+        onClick={() => nudge(-1)}
+      >
+        <Minus className="h-4 w-4" />
+      </Button>
+      <Input
+        id={id}
+        type="number"
+        inputMode="numeric"
+        min={min}
+        step={step}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="text-center [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        aria-label="Increase"
+        onClick={() => nudge(1)}
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
 
 const FIELDS: Array<{ key: keyof ApiKeys; label: string; placeholder: string; helper: string }> = [
   {
@@ -243,14 +299,12 @@ export default function SettingsPage() {
 
             <Field>
               <FieldLabel htmlFor="max-steps">Max training steps per trial</FieldLabel>
-              <Input
+              <IntegerStepper
                 id="max-steps"
-                type="text"
-                inputMode="numeric"
-                placeholder={String(DEFAULT_MAX_STEPS)}
                 value={maxSteps}
-                onChange={(e) => setMaxSteps(e.target.value)}
-                className="max-w-xs"
+                onChange={setMaxSteps}
+                step={500}
+                placeholder={String(DEFAULT_MAX_STEPS)}
               />
               <FieldDescription>
                 Caps how long each quantum model trains (model default is 10,000). Trials that hit
@@ -260,14 +314,12 @@ export default function SettingsPage() {
 
             <Field>
               <FieldLabel htmlFor="convergence-interval">Convergence interval</FieldLabel>
-              <Input
+              <IntegerStepper
                 id="convergence-interval"
-                type="text"
-                inputMode="numeric"
-                placeholder={String(DEFAULT_CONVERGENCE_INTERVAL)}
                 value={convergenceInterval}
-                onChange={(e) => setConvergenceInterval(e.target.value)}
-                className="max-w-xs"
+                onChange={setConvergenceInterval}
+                step={25}
+                placeholder={String(DEFAULT_CONVERGENCE_INTERVAL)}
               />
               <FieldDescription>
                 Steps between flat-loss convergence checks and pruning reports. Lower values let

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -6,7 +6,22 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Field, FieldDescription, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { PageShell } from '@/components/ui/page-shell';
-import { DEFAULT_DATABASE_NAME, loadAppSettings, saveAppSettings } from '@/lib/appSettings';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DEFAULT_CONVERGENCE_INTERVAL,
+  DEFAULT_DATABASE_NAME,
+  DEFAULT_MAX_STEPS,
+  DEFAULT_MAX_VMAP,
+  MAX_VMAP_OPTIONS,
+  loadAppSettings,
+  saveAppSettings,
+} from '@/lib/appSettings';
 import { type ApiKeys, loadApiKeys, saveApiKeys } from '@/lib/settings';
 import { Eye, EyeOff } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -46,6 +61,17 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [databaseName, setDatabaseName] = useState(DEFAULT_DATABASE_NAME);
   const [savedDatabaseName, setSavedDatabaseName] = useState(DEFAULT_DATABASE_NAME);
+  // Optimizer performance knobs; numeric fields kept as strings while editing.
+  const [maxVmap, setMaxVmap] = useState(String(DEFAULT_MAX_VMAP));
+  const [maxSteps, setMaxSteps] = useState(String(DEFAULT_MAX_STEPS));
+  const [convergenceInterval, setConvergenceInterval] = useState(
+    String(DEFAULT_CONVERGENCE_INTERVAL)
+  );
+  const [savedOptimizer, setSavedOptimizer] = useState({
+    maxVmap: String(DEFAULT_MAX_VMAP),
+    maxSteps: String(DEFAULT_MAX_STEPS),
+    convergenceInterval: String(DEFAULT_CONVERGENCE_INTERVAL),
+  });
 
   useEffect(() => {
     loadApiKeys()
@@ -57,10 +83,28 @@ export default function SettingsPage() {
     const appSettings = loadAppSettings();
     setDatabaseName(appSettings.databaseName);
     setSavedDatabaseName(appSettings.databaseName);
+    const optimizer = {
+      maxVmap: String(appSettings.maxVmap),
+      maxSteps: String(appSettings.maxSteps),
+      convergenceInterval: String(appSettings.convergenceInterval),
+    };
+    setMaxVmap(optimizer.maxVmap);
+    setMaxSteps(optimizer.maxSteps);
+    setConvergenceInterval(optimizer.convergenceInterval);
+    setSavedOptimizer(optimizer);
   }, []);
 
   const dirty =
-    FIELDS.some((f) => keys[f.key] !== saved[f.key]) || databaseName !== savedDatabaseName;
+    FIELDS.some((f) => keys[f.key] !== saved[f.key]) ||
+    databaseName !== savedDatabaseName ||
+    maxVmap !== savedOptimizer.maxVmap ||
+    maxSteps !== savedOptimizer.maxSteps ||
+    convergenceInterval !== savedOptimizer.convergenceInterval;
+
+  const parsePositiveInt = (raw: string, fallback: number): number => {
+    const n = Math.floor(Number(raw));
+    return Number.isFinite(n) && n >= 1 ? n : fallback;
+  };
 
   const handleSave = async () => {
     setSaving(true);
@@ -68,9 +112,23 @@ export default function SettingsPage() {
       await saveApiKeys(keys);
       setSaved(keys);
       const name = databaseName.trim() || DEFAULT_DATABASE_NAME;
-      saveAppSettings({ databaseName: name });
+      const optimizerValues = {
+        maxVmap: parsePositiveInt(maxVmap, DEFAULT_MAX_VMAP),
+        maxSteps: parsePositiveInt(maxSteps, DEFAULT_MAX_STEPS),
+        convergenceInterval: parsePositiveInt(convergenceInterval, DEFAULT_CONVERGENCE_INTERVAL),
+      };
+      saveAppSettings({ databaseName: name, ...optimizerValues });
       setDatabaseName(name);
       setSavedDatabaseName(name);
+      const optimizer = {
+        maxVmap: String(optimizerValues.maxVmap),
+        maxSteps: String(optimizerValues.maxSteps),
+        convergenceInterval: String(optimizerValues.convergenceInterval),
+      };
+      setMaxVmap(optimizer.maxVmap);
+      setMaxSteps(optimizer.maxSteps);
+      setConvergenceInterval(optimizer.convergenceInterval);
+      setSavedOptimizer(optimizer);
       toast.success('Settings saved');
     } catch {
       toast.error('Could not save settings');
@@ -152,6 +210,68 @@ export default function SettingsPage() {
               <FieldDescription>
                 Optuna SQLite database used for all optimization runs (stored server-side under{' '}
                 <code className="font-mono">db/&lt;name&gt;.db</code>).
+              </FieldDescription>
+            </Field>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Optimizer Performance</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <Field>
+              <FieldLabel htmlFor="max-vmap">Circuit vectorization (max_vmap)</FieldLabel>
+              <Select value={maxVmap} onValueChange={setMaxVmap}>
+                <SelectTrigger id="max-vmap" className="w-full max-w-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MAX_VMAP_OPTIONS.map((v) => (
+                    <SelectItem key={v} value={String(v)}>
+                      {v}
+                      {v === DEFAULT_MAX_VMAP ? ' (default)' : v === 1 ? ' (slowest)' : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldDescription>
+                Quantum circuit evaluations vectorized per JAX call. Higher is much faster on small
+                datasets but uses more memory. Must divide the batch size (32).
+              </FieldDescription>
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="max-steps">Max training steps per trial</FieldLabel>
+              <Input
+                id="max-steps"
+                type="text"
+                inputMode="numeric"
+                placeholder={String(DEFAULT_MAX_STEPS)}
+                value={maxSteps}
+                onChange={(e) => setMaxSteps(e.target.value)}
+                className="max-w-xs"
+              />
+              <FieldDescription>
+                Caps how long each quantum model trains (model default is 10,000). Trials that hit
+                the cap without converging are still scored.
+              </FieldDescription>
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="convergence-interval">Convergence interval</FieldLabel>
+              <Input
+                id="convergence-interval"
+                type="text"
+                inputMode="numeric"
+                placeholder={String(DEFAULT_CONVERGENCE_INTERVAL)}
+                value={convergenceInterval}
+                onChange={(e) => setConvergenceInterval(e.target.value)}
+                className="max-w-xs"
+              />
+              <FieldDescription>
+                Steps between flat-loss convergence checks and pruning reports. Lower values let
+                converged trials exit sooner and give the pruner earlier decision points.
               </FieldDescription>
             </Field>
           </CardContent>

--- a/frontend/components/optimizer/steps/OptimizeStep.tsx
+++ b/frontend/components/optimizer/steps/OptimizeStep.tsx
@@ -59,8 +59,11 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
     try {
       const finalStatus = await pollOptimization(id, (status, trialsData) => {
         // The live trial list from the Optuna DB is fresher than the job's
-        // current_trial counter; prefer it when available.
-        const trialCount = trialsData?.trials?.length ?? status.current_trial;
+        // current_trial counter; prefer it when available. Count finished
+        // trials only — RUNNING rows would advance progress prematurely.
+        const trialCount = trialsData?.trials
+          ? trialsData.trials.filter((t) => t.state !== 'RUNNING').length
+          : status.current_trial;
         setCurrentTrial(trialCount);
         setProgress(status.total_trials ? (trialCount / status.total_trials) * 100 : 0);
         if (trialsData?.trials) {
@@ -347,8 +350,10 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
               <TableBody>
                 {sorted.map((trial, index) => {
                   const pruned = trial.state === 'PRUNED';
-                  const failed = !pruned && (trial.value === null || trial.state === 'FAIL');
-                  const selectable = hasResults && !failed && !pruned;
+                  const running = trial.state === 'RUNNING';
+                  const failed =
+                    !pruned && !running && (trial.value === null || trial.state === 'FAIL');
+                  const selectable = hasResults && !failed && !pruned && !running;
                   const selected = optimization.selectedTrial === trial.trial;
                   const classical = isClassicalModel(trial.params?.model_type);
                   const isBest = index === 0 && !failed;
@@ -391,7 +396,20 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
                           selected && 'text-brand'
                         )}
                       >
-                        {pruned ? (
+                        {running ? (
+                          <span
+                            className="font-medium text-brand"
+                            title={
+                              trial.n_reports
+                                ? `${trial.n_reports} intermediate report${trial.n_reports === 1 ? '' : 's'} so far`
+                                : 'Training in progress'
+                            }
+                          >
+                            {trial.last_intermediate_value != null
+                              ? `~${trial.last_intermediate_value.toFixed(4)}`
+                              : 'running…'}
+                          </span>
+                        ) : pruned ? (
                           <span
                             className="font-medium text-muted-foreground"
                             title={

--- a/frontend/components/optimizer/steps/OptimizeStep.tsx
+++ b/frontend/components/optimizer/steps/OptimizeStep.tsx
@@ -22,7 +22,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { fetchOptimizationTrials, pollOptimization, startOptimization } from '@/lib/api';
-import { getDatabaseName } from '@/lib/appSettings';
+import { getDatabaseName, getOptimizerSettings } from '@/lib/appSettings';
 import { cn } from '@/lib/utils';
 import { Atom, Check, Cpu, PlayCircle, RotateCcw, Trophy } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -128,6 +128,7 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
         ? { neg: features.labelMapping.neg, pos: features.labelMapping.pos }
         : undefined;
 
+    const optimizerSettings = getOptimizerSettings();
     try {
       const { id } = await startOptimization({
         dataset_id: dataset.id,
@@ -142,6 +143,9 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
         categorical_encoding: features.categoricalEncoding,
         sampler: configuration.sampler,
         pruner: configuration.pruner,
+        max_steps: optimizerSettings.maxSteps,
+        convergence_interval: optimizerSettings.convergenceInterval,
+        max_vmap: optimizerSettings.maxVmap,
       });
 
       // Persist the execution id immediately so a refresh mid-run can resume.

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -113,6 +113,10 @@ export interface OptimizationRequest {
   // Search strategy: sampler + optional early-stopping pruner (ASHA/Hyperband).
   sampler?: 'tpe' | 'random' | 'grid';
   pruner?: 'none' | 'asha' | 'hyperband';
+  // Performance knobs (Settings → Optimizer Performance).
+  max_steps?: number;
+  convergence_interval?: number;
+  max_vmap?: number;
 }
 
 export type RunStatus =

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -144,11 +144,14 @@ export interface OptimizationStatus {
 
 export interface OptimizationTrial {
   trial: number;
-  // null for FAILED trials; user_attrs.error records the failure reason.
+  // null for FAILED/PRUNED/RUNNING trials; user_attrs.error records failures.
   value: number | null;
   params: Record<string, any>;
   state: string;
   user_attrs?: Record<string, any>;
+  // Live pruning telemetry: intermediate reports made so far + latest value.
+  n_reports?: number;
+  last_intermediate_value?: number | null;
 }
 
 export interface OptimizationTrials {

--- a/frontend/lib/appSettings.ts
+++ b/frontend/lib/appSettings.ts
@@ -10,11 +10,31 @@ const STORAGE_KEY = 'quoptuna.appSettings.v1';
 
 export const DEFAULT_DATABASE_NAME = 'results';
 
+// Optimizer performance defaults. Deliberately faster than the model-class
+// defaults (max_vmap 1 / max_steps 10000 / convergence_interval 200): on the
+// small tabular datasets QuOptuna targets, vectorized circuits and a tighter
+// step budget cut trial wall-clock severalfold.
+export const DEFAULT_MAX_VMAP = 32;
+export const DEFAULT_MAX_STEPS = 2000;
+export const DEFAULT_CONVERGENCE_INTERVAL = 100;
+
+// train() requires batch_size % max_vmap == 0; batch size is 32 in the
+// default search space, so valid widths are its divisors.
+export const MAX_VMAP_OPTIONS = [1, 2, 4, 8, 16, 32] as const;
+
 export interface AppSettings {
   databaseName: string;
+  maxVmap: number;
+  maxSteps: number;
+  convergenceInterval: number;
 }
 
-const DEFAULTS: AppSettings = { databaseName: DEFAULT_DATABASE_NAME };
+const DEFAULTS: AppSettings = {
+  databaseName: DEFAULT_DATABASE_NAME,
+  maxVmap: DEFAULT_MAX_VMAP,
+  maxSteps: DEFAULT_MAX_STEPS,
+  convergenceInterval: DEFAULT_CONVERGENCE_INTERVAL,
+};
 
 export function loadAppSettings(): AppSettings {
   if (typeof window === 'undefined') return { ...DEFAULTS };
@@ -36,4 +56,27 @@ export function saveAppSettings(settings: AppSettings): void {
 export function getDatabaseName(): string {
   const name = loadAppSettings().databaseName.trim() || DEFAULT_DATABASE_NAME;
   return name.replace(/\.db$/i, '') || DEFAULT_DATABASE_NAME;
+}
+
+function sanitizeInt(value: unknown, fallback: number): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) && n >= 1 ? n : fallback;
+}
+
+/** Optimizer performance knobs for new runs, sanitized to safe values. */
+export function getOptimizerSettings(): {
+  maxVmap: number;
+  maxSteps: number;
+  convergenceInterval: number;
+} {
+  const s = loadAppSettings();
+  const rawVmap = sanitizeInt(s.maxVmap, DEFAULT_MAX_VMAP);
+  // Snap to the largest valid divisor of the batch size (32) not above the
+  // stored value, so a hand-edited localStorage value can't crash train().
+  const maxVmap = [...MAX_VMAP_OPTIONS].reverse().find((v) => v <= rawVmap) ?? 1;
+  return {
+    maxVmap,
+    maxSteps: sanitizeInt(s.maxSteps, DEFAULT_MAX_STEPS),
+    convergenceInterval: sanitizeInt(s.convergenceInterval, DEFAULT_CONVERGENCE_INTERVAL),
+  };
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quoptuna"
-version = "0.1.0"
+version = "0.1.1"
 description = "quoptuna is a proposed open-source project that combines quantum computing with Optuna's hyperparameter optimization framework."
 authors = [
     {name = "Edwin Jose", email = "edwinjose900@gmail.com"},

--- a/src/quoptuna/backend/base/pennylane_models/qml_benchmarks/model_utils.py
+++ b/src/quoptuna/backend/base/pennylane_models/qml_benchmarks/model_utils.py
@@ -130,6 +130,9 @@ def train(model, loss_fn, optimizer, X, y, random_key_generator, convergence_int
 
     if not converged:
         print("Loss did not converge:", loss_history)
+        # Keep the trained parameters on the model: callers that choose to
+        # tolerate non-convergence can still score/use it as-is.
+        model.params_ = params
         raise ConvergenceWarning(
             f"Model {model.__class__.__name__} has not converged after the maximum number of {model.max_steps} steps."
         )

--- a/src/quoptuna/backend/base/pennylane_models/qml_benchmarks/models/quantum_kitchen_sinks.py
+++ b/src/quoptuna/backend/base/pennylane_models/qml_benchmarks/models/quantum_kitchen_sinks.py
@@ -32,7 +32,10 @@ from quoptuna.backend.base.pennylane_models.qml_benchmarks.model_utils import (
 class QuantumKitchenSinks(BaseEstimator, ClassifierMixin):
     def __init__(
         self,
-        linear_model=LogisticRegression(penalty=None, solver="lbfgs", tol=10e-4),
+        # max_iter raised from sklearn's default 100: unregularized lbfgs on
+        # separable quantum features routinely needs more iterations and
+        # otherwise emits ConvergenceWarning on every fit.
+        linear_model=LogisticRegression(penalty=None, solver="lbfgs", tol=10e-4, max_iter=1000),
         n_episodes=100,
         n_qfeatures="full",
         var=1.0,

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -84,6 +84,8 @@ class Optimizer:
         pruner_reduction_factor: int = 3,
         intermediate_metric: str = "accuracy",
         max_steps: Optional[int] = None,  # noqa: FA100
+        convergence_interval: Optional[int] = None,  # noqa: FA100
+        max_vmap: Optional[int] = None,  # noqa: FA100
     ):
         """Initialize the Optimizer class.
 
@@ -107,6 +109,11 @@ class Optimizer:
                 or "neg_loss" (negated recent training loss; cheaper, but only
                 meaningful when a single model type is searched).
             max_steps: Optional cap on training steps for iterative models.
+            convergence_interval: Optional override of the models' flat-loss
+                convergence window (also the cadence of pruning reports).
+            max_vmap: Optional override of the ``max_vmap`` search-space entry
+                (circuit evaluations vectorized per JAX call). Must divide the
+                batch size.
 
         Attributes:
             db_name: The name of the database.
@@ -147,6 +154,11 @@ class Optimizer:
         self.pruner_reduction_factor = pruner_reduction_factor
         self.intermediate_metric = intermediate_metric
         self.max_steps = max_steps
+        self.convergence_interval = convergence_interval
+        if max_vmap is not None and "max_vmap" in self.search_space:
+            # Override the vectorization width without touching other entries;
+            # objective() keeps sampling it like any other hyperparameter.
+            self.search_space = {**self.search_space, "max_vmap": [max_vmap]}
 
     def _build_sampler(self):
         if self.sampler == "tpe":
@@ -195,7 +207,12 @@ class Optimizer:
 
             model_type = trial.suggest_categorical("model_type", self.model_types)
 
-            model = create_model(model_type, max_steps=self.max_steps, **params)
+            model = create_model(
+                model_type,
+                max_steps=self.max_steps,
+                convergence_interval=self.convergence_interval,
+                **params,
+            )
 
             # Iterative (JAX-trained) models report intermediate values so the
             # pruner can stop unpromising trials early. Kernel/sklearn models

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -6,6 +6,7 @@ import numpy as np
 from optuna import Trial, TrialPruned, create_study, load_study
 from optuna.pruners import HyperbandPruner, NopPruner, SuccessiveHalvingPruner
 from optuna.samplers import GridSampler, RandomSampler, TPESampler
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.metrics import accuracy_score, f1_score
 
 from quoptuna.backend.models import create_model
@@ -202,7 +203,15 @@ class Optimizer:
             if self.pruner != "none" and hasattr(model, "max_steps"):
                 model.training_callback = self._make_pruning_callback(trial, model)
 
-            model.fit(self.train_x, self.train_y)
+            try:
+                model.fit(self.train_x, self.train_y)
+                trial.set_user_attr("converged", True)
+            except ConvergenceWarning:
+                # The training loop hit max_steps without meeting the flat-loss
+                # criterion. The partially-trained parameters are still valid —
+                # score the model instead of discarding max_steps of compute.
+                logger.warning("Trial %s did not converge; scoring anyway", trial.number)
+                trial.set_user_attr("converged", False)
             score = model.score(self.test_x, self.test_y)
 
             f_score_ = f1_score(self.test_y, model.predict(self.test_x))
@@ -232,16 +241,34 @@ class Optimizer:
             self._log_resource_attributes(trial, model)
             raise
 
+    # Validation subset cap for the "accuracy" intermediate metric. Quantum
+    # predicts run in max_vmap-sized chunks, so evaluating the full test set at
+    # every report can rival the cost of training itself for some models
+    # (e.g. QuantumMetricLearner). A fixed prefix keeps values comparable
+    # across trials while bounding the per-report circuit count.
+    VALIDATION_SUBSET_SIZE = 128
+
     def _make_pruning_callback(self, trial: Trial, model):
-        """Build the per-interval hook consumed by ``model_utils.train``."""
+        """Build the per-interval hook consumed by ``model_utils.train``.
+
+        The pruner is fed the *report index* (0, 1, 2, ...), not the raw
+        training step, so ``pruner_min_resource``/``pruner_reduction_factor``
+        operate in units of intermediate reports as documented. Raw steps
+        would let a single report jump several ASHA rungs at once.
+        """
+        val_x = self.test_x[: self.VALIDATION_SUBSET_SIZE]
+        val_y = self.test_y[: self.VALIDATION_SUBSET_SIZE]
+        report_count = {"n": 0}
 
         def callback(step, loss_history):
             if self.intermediate_metric == "neg_loss":
                 window = getattr(model, "convergence_interval", 200)
                 value = -float(np.mean(loss_history[-window:]))
             else:
-                value = float(accuracy_score(self.test_y, model.predict(self.test_x)))
-            trial.report(value, step=step)
+                value = float(accuracy_score(val_y, model.predict(val_x)))
+            report_index = report_count["n"]
+            report_count["n"] += 1
+            trial.report(value, step=report_index)
             if trial.should_prune():
                 trial.set_user_attr("pruned_at_step", int(step))
                 msg = f"Pruned at step {step} ({self.intermediate_metric}={value:.4f})"

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -222,13 +222,13 @@ class Optimizer:
 
             try:
                 model.fit(self.train_x, self.train_y)
-                trial.set_user_attr("converged", True)
+                trial.set_user_attr(key="converged", value=True)
             except ConvergenceWarning:
                 # The training loop hit max_steps without meeting the flat-loss
                 # criterion. The partially-trained parameters are still valid —
                 # score the model instead of discarding max_steps of compute.
                 logger.warning("Trial %s did not converge; scoring anyway", trial.number)
-                trial.set_user_attr("converged", False)
+                trial.set_user_attr(key="converged", value=False)
             score = model.score(self.test_x, self.test_y)
 
             f_score_ = f1_score(self.test_y, model.predict(self.test_x))
@@ -273,8 +273,13 @@ class Optimizer:
         operate in units of intermediate reports as documented. Raw steps
         would let a single report jump several ASHA rungs at once.
         """
-        val_x = self.test_x[: self.VALIDATION_SUBSET_SIZE]
-        val_y = self.test_y[: self.VALIDATION_SUBSET_SIZE]
+        test_x = self.test_x
+        test_y = self.test_y
+        if test_x is None or test_y is None:
+            msg = "Pruning callback requires test features and labels"
+            raise ValueError(msg)
+        val_x = test_x[: self.VALIDATION_SUBSET_SIZE]
+        val_y = test_y[: self.VALIDATION_SUBSET_SIZE]
         report_count = {"n": 0}
 
         def callback(step, loss_history):

--- a/src/quoptuna/server/api/v1/optimize.py
+++ b/src/quoptuna/server/api/v1/optimize.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from optuna.trial import TrialState
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from quoptuna.server.services import dataset_registry, run_store
 from quoptuna.server.services.storage import optuna_storage_url
@@ -62,7 +62,13 @@ class OptimizationRequest(BaseModel):
     # Intermediate value iterative models report for pruning decisions.
     intermediate_metric: Literal["accuracy", "neg_loss"] = "accuracy"
     # Optional cap on training steps for iterative models.
-    max_steps: Optional[int] = None
+    max_steps: Optional[int] = Field(default=None, ge=1)
+    # Optional override of the flat-loss convergence window (also the cadence
+    # of pruning reports).
+    convergence_interval: Optional[int] = Field(default=None, ge=1)
+    # Optional override of circuit-evaluation vectorization width; must divide
+    # the batch size (32 in the default search space).
+    max_vmap: Optional[int] = Field(default=None, ge=1)
 
 
 class OptimizationStatus(BaseModel):
@@ -152,6 +158,8 @@ def build_workflow(
                     "pruner_reduction_factor": request.pruner_reduction_factor,
                     "intermediate_metric": request.intermediate_metric,
                     "max_steps": request.max_steps,
+                    "convergence_interval": request.convergence_interval,
+                    "max_vmap": request.max_vmap,
                 },
             },
         },

--- a/src/quoptuna/server/api/v1/optimize.py
+++ b/src/quoptuna/server/api/v1/optimize.py
@@ -406,22 +406,33 @@ async def get_optimization_trials(optimization_id: str):
         best_value = None
         best_params = None
 
+        finished_count = 0
         for trial in study.trials:
-            # Skip in-flight trials: they have no value yet and would both
-            # inflate the progress count and show up as a bogus 0.0 score.
-            if not trial.state.is_finished():
+            # Include RUNNING trials so the UI can show live training progress
+            # (intermediate pruning reports); skip WAITING/other states.
+            is_running = trial.state == TrialState.RUNNING
+            if not (trial.state.is_finished() or is_running):
                 continue
+            if trial.state.is_finished():
+                finished_count += 1
             # FAILED trials keep value=None (coercing to 0.0 made broken
             # configurations look like real F1=0 runs); the recorded "error"
-            # user attr says why. PRUNED trials also expose None: their stored
-            # value is the last intermediate report, not a final F1.
+            # user attr says why. PRUNED/RUNNING trials also expose None: their
+            # stored value is the last intermediate report, not a final F1.
             is_complete = trial.state == TrialState.COMPLETE
+            intermediate = trial.intermediate_values
             trial_data = {
                 "trial": trial.number,
                 "value": trial.value if is_complete else None,
                 "params": trial.params,
                 "state": trial.state.name,
                 "user_attrs": trial.user_attrs,
+                # Live pruning telemetry: how many intermediate reports the
+                # trial has made and the latest reported value.
+                "n_reports": len(intermediate),
+                "last_intermediate_value": (
+                    intermediate[max(intermediate)] if intermediate else None
+                ),
             }
             trials.append(trial_data)
 
@@ -434,13 +445,14 @@ async def get_optimization_trials(optimization_id: str):
                 best_value = trial.value
                 best_params = trial.params
 
-        # Update job with latest data
+        # Update job with latest data (progress counts finished trials only —
+        # a RUNNING row would advance the progress bar prematurely).
         job["trials"] = trials
-        job["current_trial"] = len(trials)
+        job["current_trial"] = finished_count
         if best_value is not None:
             job["best_value"] = best_value
             job["best_params"] = best_params
-        progress: Dict[str, Any] = {"current_trial": len(trials)}
+        progress: Dict[str, Any] = {"current_trial": finished_count}
         if best_value is not None:
             progress.update(best_value=best_value, best_params=best_params)
         run_store.update_run(optimization_id, **progress)

--- a/src/quoptuna/server/services/workflow_service.py
+++ b/src/quoptuna/server/services/workflow_service.py
@@ -426,6 +426,8 @@ class WorkflowExecutor:
             "pruner_reduction_factor": config.get("pruner_reduction_factor", 3),
             "intermediate_metric": config.get("intermediate_metric", "accuracy"),
             "max_steps": config.get("max_steps"),
+            "convergence_interval": config.get("convergence_interval"),
+            "max_vmap": config.get("max_vmap"),
         }
 
         # Merge input data if available
@@ -473,6 +475,8 @@ class WorkflowExecutor:
             pruner_reduction_factor=opt_config.get("pruner_reduction_factor", 3),
             intermediate_metric=opt_config.get("intermediate_metric", "accuracy"),
             max_steps=opt_config.get("max_steps"),
+            convergence_interval=opt_config.get("convergence_interval"),
+            max_vmap=opt_config.get("max_vmap"),
         )
 
         # Run optimization

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -11,6 +11,7 @@ import numpy as np
 import optuna
 import pytest
 from optuna.trial import FixedTrial
+from sklearn.exceptions import ConvergenceWarning
 
 from quoptuna.backend.tuners import optimizer as optimizer_module
 from quoptuna.backend.tuners.optimizer import (
@@ -26,6 +27,9 @@ ITERATIVE_MAX_STEPS = 12
 ITERATIVE_BATCH_SIZE = 4
 FIRST_PRUNE_CALLBACK_STEP = 2
 PRUNED_TRIAL_COUNT = 3
+UNCONVERGED_MAX_STEPS = 12
+CONVERGENCE_TEST_MAX_STEPS = 500
+CONVERGENCE_TEST_INTERVAL = 50
 
 
 class _FakeModel:
@@ -283,8 +287,6 @@ def test_optimize_without_pruner_attaches_no_callback(tiny_data, monkeypatch):
 def test_pruner_reports_use_report_index(tiny_data, monkeypatch):
     """ASHA rungs must be fed the report index (0,1,2,...), not raw training
     steps, so min_resource/reduction_factor mean 'number of reports'."""
-    import optuna
-
     monkeypatch.setattr(
         optimizer_module,
         "create_model",
@@ -308,15 +310,14 @@ def test_pruner_reports_use_report_index(tiny_data, monkeypatch):
 def test_unconverged_trial_is_scored_not_failed(tiny_data, monkeypatch):
     """ConvergenceWarning from the training loop must not waste the trial:
     the partially-trained model is scored and the trial completes."""
-    from sklearn.exceptions import ConvergenceWarning
-
     class _UnconvergedModel(_FakeModel):
-        max_steps = 12
+        max_steps = UNCONVERGED_MAX_STEPS
 
         def fit(self, _x, _y):
             self.loss_history_ = np.ones(self.max_steps)
             self.training_time_ = 0.05
-            raise ConvergenceWarning("did not converge")
+            msg = "did not converge"
+            raise ConvergenceWarning(msg)
 
     monkeypatch.setattr(
         optimizer_module,
@@ -335,7 +336,7 @@ def test_unconverged_trial_is_scored_not_failed(tiny_data, monkeypatch):
     assert trial.state.name == "COMPLETE"
     assert trial.value is not None
     assert trial.user_attrs["converged"] is False
-    assert trial.user_attrs["n_steps"] == 12
+    assert trial.user_attrs["n_steps"] == UNCONVERGED_MAX_STEPS
 
 
 def test_max_vmap_override_replaces_search_space_entry():
@@ -361,10 +362,10 @@ def test_convergence_interval_reaches_create_model(tiny_data, monkeypatch):
         data=tiny_data,
         model_types=["SVC"],
         search_space=TINY_SEARCH_SPACE,
-        max_steps=500,
-        convergence_interval=50,
+        max_steps=CONVERGENCE_TEST_MAX_STEPS,
+        convergence_interval=CONVERGENCE_TEST_INTERVAL,
     )
     trial = FixedTrial({"C": 1.0, "model_type": "SVC"})
     opt.objective(trial)
-    assert captured["max_steps"] == 500
-    assert captured["convergence_interval"] == 50
+    assert captured["max_steps"] == CONVERGENCE_TEST_MAX_STEPS
+    assert captured["convergence_interval"] == CONVERGENCE_TEST_INTERVAL

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -310,6 +310,7 @@ def test_pruner_reports_use_report_index(tiny_data, monkeypatch):
 def test_unconverged_trial_is_scored_not_failed(tiny_data, monkeypatch):
     """ConvergenceWarning from the training loop must not waste the trial:
     the partially-trained model is scored and the trial completes."""
+
     class _UnconvergedModel(_FakeModel):
         max_steps = UNCONVERGED_MAX_STEPS
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -336,3 +336,35 @@ def test_unconverged_trial_is_scored_not_failed(tiny_data, monkeypatch):
     assert trial.value is not None
     assert trial.user_attrs["converged"] is False
     assert trial.user_attrs["n_steps"] == 12
+
+
+def test_max_vmap_override_replaces_search_space_entry():
+    opt = Optimizer(db_name="unit_vmap", max_vmap=32)
+    assert opt.search_space["max_vmap"] == [32]
+    # Other entries untouched.
+    assert opt.search_space["batch_size"] == DEFAULT_SEARCH_SPACE["batch_size"]
+    # No-op when the (custom) space has no max_vmap key.
+    opt2 = Optimizer(db_name="unit_vmap2", search_space={"C": [1.0]}, max_vmap=32)
+    assert "max_vmap" not in opt2.search_space
+
+
+def test_convergence_interval_reaches_create_model(tiny_data, monkeypatch):
+    captured = {}
+
+    def _factory(model_type, **kwargs):
+        captured.update(kwargs)
+        return _FakeModel(model_type=model_type)
+
+    monkeypatch.setattr(optimizer_module, "create_model", _factory)
+    opt = Optimizer(
+        db_name="unit_ci",
+        data=tiny_data,
+        model_types=["SVC"],
+        search_space=TINY_SEARCH_SPACE,
+        max_steps=500,
+        convergence_interval=50,
+    )
+    trial = FixedTrial({"C": 1.0, "model_type": "SVC"})
+    opt.objective(trial)
+    assert captured["max_steps"] == 500
+    assert captured["convergence_interval"] == 50

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -278,3 +278,61 @@ def test_optimize_without_pruner_attaches_no_callback(tiny_data, monkeypatch):
     assert trial.user_attrs["pruned"] is False
     assert trial.user_attrs["n_steps"] == ITERATIVE_MAX_STEPS
     assert trial.user_attrs["batch_size"] == ITERATIVE_BATCH_SIZE
+
+
+def test_pruner_reports_use_report_index(tiny_data, monkeypatch):
+    """ASHA rungs must be fed the report index (0,1,2,...), not raw training
+    steps, so min_resource/reduction_factor mean 'number of reports'."""
+    import optuna
+
+    monkeypatch.setattr(
+        optimizer_module,
+        "create_model",
+        lambda model_type, **kwargs: _FakeIterativeModel(model_type=model_type, **kwargs),
+    )
+    opt = Optimizer(
+        db_name="unit_rung",
+        study_name="rung_study",
+        data=tiny_data,
+        model_types=["DataReuploadingClassifier"],
+        search_space=TINY_SEARCH_SPACE,
+        pruner="asha",
+        intermediate_metric="neg_loss",
+    )
+    study, _ = opt.optimize(n_trials=1)
+    (trial,) = study.trials
+    # max_steps=12, interval=3 -> 4 reports at indices 0..3 (not steps 2,5,8,11).
+    assert sorted(trial.intermediate_values.keys()) == [0, 1, 2, 3]
+
+
+def test_unconverged_trial_is_scored_not_failed(tiny_data, monkeypatch):
+    """ConvergenceWarning from the training loop must not waste the trial:
+    the partially-trained model is scored and the trial completes."""
+    from sklearn.exceptions import ConvergenceWarning
+
+    class _UnconvergedModel(_FakeModel):
+        max_steps = 12
+
+        def fit(self, _x, _y):
+            self.loss_history_ = np.ones(self.max_steps)
+            self.training_time_ = 0.05
+            raise ConvergenceWarning("did not converge")
+
+    monkeypatch.setattr(
+        optimizer_module,
+        "create_model",
+        lambda model_type, **kwargs: _UnconvergedModel(model_type=model_type, **kwargs),
+    )
+    opt = Optimizer(
+        db_name="unit_noconv",
+        study_name="noconv_study",
+        data=tiny_data,
+        model_types=["DataReuploadingClassifier"],
+        search_space=TINY_SEARCH_SPACE,
+    )
+    study, _ = opt.optimize(n_trials=1)
+    (trial,) = study.trials
+    assert trial.state.name == "COMPLETE"
+    assert trial.value is not None
+    assert trial.user_attrs["converged"] is False
+    assert trial.user_attrs["n_steps"] == 12

--- a/uv.lock
+++ b/uv.lock
@@ -3328,7 +3328,7 @@ wheels = [
 
 [[package]]
 name = "quoptuna"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "cairosvg" },


### PR DESCRIPTION
This pull request introduces a set of improvements to the optimizer performance configuration, user interface, and backend handling of quantum model optimization. The main focus is to allow users to tune optimizer performance parameters (such as vectorization width, training steps, and convergence interval) from the UI, persist these settings, and ensure they are respected throughout the optimization workflow. Additionally, the PR improves trial state handling and reporting in the UI and backend.

The most important changes are:

**Frontend: Optimizer Performance Settings**
- Added a new "Optimizer Performance" card in the settings page (`frontend/app/settings/page.tsx`) allowing users to configure `max_vmap`, `max_steps`, and `convergence_interval` with user-friendly controls. These settings are persisted and validated for safe values. [[1]](diffhunk://#diff-490eed05723647ee1286a4486c413d13a487aae5776bea789c214c59bc0935e1L9-R85) [[2]](diffhunk://#diff-490eed05723647ee1286a4486c413d13a487aae5776bea789c214c59bc0935e1R120-R130) [[3]](diffhunk://#diff-490eed05723647ee1286a4486c413d13a487aae5776bea789c214c59bc0935e1R142-R187) [[4]](diffhunk://#diff-490eed05723647ee1286a4486c413d13a487aae5776bea789c214c59bc0935e1R274-R331) [[5]](diffhunk://#diff-2941614716f9f62c79611e80fc949e5434b88c9341e300ecf016cd1d5b04f776R13-R37) [[6]](diffhunk://#diff-2941614716f9f62c79611e80fc949e5434b88c9341e300ecf016cd1d5b04f776R60-R82)
- The optimizer step in the workflow (`frontend/components/optimizer/steps/OptimizeStep.tsx`) now reads these settings and passes them to the backend when starting a new optimization run. [[1]](diffhunk://#diff-ba40e9e0d952d47d97aa96ce6cfc71090dfb63d03e97efcfc2f25d01e1a54bc9L25-R25) [[2]](diffhunk://#diff-ba40e9e0d952d47d97aa96ce6cfc71090dfb63d03e97efcfc2f25d01e1a54bc9R131) [[3]](diffhunk://#diff-ba40e9e0d952d47d97aa96ce6cfc71090dfb63d03e97efcfc2f25d01e1a54bc9R146-R148)

**Frontend: Trial State Reporting and Selection**
- Improved the display and logic for trial states in the optimization results table: running, pruned, and failed trials are now distinguished, and only completed, non-failed, non-pruned trials are selectable. Running trials show their latest intermediate value and report count. [[1]](diffhunk://#diff-ba40e9e0d952d47d97aa96ce6cfc71090dfb63d03e97efcfc2f25d01e1a54bc9L62-R66) [[2]](diffhunk://#diff-ba40e9e0d952d47d97aa96ce6cfc71090dfb63d03e97efcfc2f25d01e1a54bc9L350-R360) [[3]](diffhunk://#diff-ba40e9e0d952d47d97aa96ce6cfc71090dfb63d03e97efcfc2f25d01e1a54bc9L394-R416) [[4]](diffhunk://#diff-dd82d4368feee55ae4f31256b3dc63118a2d39f89fccc8efdfe796e3fb8d8b6fL147-R158)

**Backend: Model and Training Improvements**
- The quantum kitchen sinks model's default `LogisticRegression` now uses `max_iter=1000` to reduce spurious convergence warnings on quantum features.
- When a model fails to converge, its trained parameters are still retained, allowing scoring and use of partially-trained models.

**Documentation Updates**
- Expanded documentation on how the pruner operates, the meaning of optimizer performance knobs, and guidance for handling non-converging trials. [[1]](diffhunk://#diff-b56950e010da759cdc628db9940deeddd0852089e414758fe46772f35fc67a3bR29-R45) [[2]](diffhunk://#diff-b56950e010da759cdc628db9940deeddd0852089e414758fe46772f35fc67a3bR57-R73)

**API and Types**
- Updated API interfaces to support the new optimizer performance parameters and improved trial telemetry (e.g., number of intermediate reports, latest value). [[1]](diffhunk://#diff-dd82d4368feee55ae4f31256b3dc63118a2d39f89fccc8efdfe796e3fb8d8b6fR116-R119) [[2]](diffhunk://#diff-dd82d4368feee55ae4f31256b3dc63118a2d39f89fccc8efdfe796e3fb8d8b6fL147-R158)

These changes make the optimizer more configurable and user-friendly, improve transparency of optimization progress, and ensure robust handling of edge cases in quantum model training.