### PR TITLE
feat: Add fairness-based search with metrics and UI enhancements

### DIFF
--- a/frontend/app/runs/page.tsx
+++ b/frontend/app/runs/page.tsx
@@ -106,6 +106,9 @@ export default function RunsPage() {
           numTrials: req.num_trials ?? 50,
           sampler: req.sampler ?? 'tpe',
           pruner: req.pruner ?? 'none',
+          fairnessMode: req.fairness_mode ?? 'off',
+          fairnessMetric: req.fairness_metric ?? 'equal_opportunity_difference',
+          fairnessThreshold: req.fairness_threshold ?? null,
         },
         optimization: {
           executionId: detail.id,
@@ -114,6 +117,7 @@ export default function RunsPage() {
           bestParams: detail.best_params,
           trials: [],
           selectedTrial: null,
+          paretoTrials: null,
         },
         analysis: { ...initialWorkflowData.analysis },
         report: { markdown: null },

--- a/frontend/components/optimizer/steps/ConfigureStep.tsx
+++ b/frontend/components/optimizer/steps/ConfigureStep.tsx
@@ -26,6 +26,8 @@ const PRESETS = [
 
 export function ConfigureStep({ workflowData, setWorkflowData, setFooter }: StepProps) {
   const { configuration } = workflowData;
+  const sensitiveFeature = workflowData.features.sensitiveFeature;
+  const fairnessOn = configuration.fairnessMode !== 'off';
 
   const hasStudyName = configuration.studyName.trim().length > 0;
 
@@ -33,11 +35,26 @@ export function ConfigureStep({ workflowData, setWorkflowData, setFooter }: Step
     setFooter({ canContinue: hasStudyName });
   }, [hasStudyName, setFooter]);
 
-  const update = (field: keyof typeof configuration, value: string | number) =>
+  const update = (field: keyof typeof configuration, value: string | number | null) =>
     setWorkflowData((prev) => ({
       ...prev,
       configuration: { ...prev.configuration, [field]: value },
     }));
+
+  // The backend rejects incompatible combinations; keep them impossible here:
+  // constraints are TPE-only, multi-objective studies cannot prune.
+  const setFairnessMode = (mode: string) =>
+    setWorkflowData((prev) => ({
+      ...prev,
+      configuration: {
+        ...prev.configuration,
+        fairnessMode: mode as typeof prev.configuration.fairnessMode,
+        sampler: mode === 'constrained' ? 'tpe' : prev.configuration.sampler,
+        pruner: mode === 'multi_objective' ? 'none' : prev.configuration.pruner,
+      },
+    }));
+
+  const defaultThreshold = configuration.fairnessMetric === 'disparate_impact' ? 0.8 : 0.1;
 
   return (
     <div className="space-y-4">
@@ -126,7 +143,11 @@ export function ConfigureStep({ workflowData, setWorkflowData, setFooter }: Step
             <Field>
               <FieldLabel htmlFor="sampler">Sampler</FieldLabel>
               <Select value={configuration.sampler} onValueChange={(v) => update('sampler', v)}>
-                <SelectTrigger id="sampler" className="w-full max-w-xs">
+                <SelectTrigger
+                  id="sampler"
+                  className="w-full max-w-xs"
+                  disabled={configuration.fairnessMode === 'constrained'}
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -144,7 +165,11 @@ export function ConfigureStep({ workflowData, setWorkflowData, setFooter }: Step
             <Field>
               <FieldLabel htmlFor="pruner">Pruner</FieldLabel>
               <Select value={configuration.pruner} onValueChange={(v) => update('pruner', v)}>
-                <SelectTrigger id="pruner" className="w-full max-w-xs">
+                <SelectTrigger
+                  id="pruner"
+                  className="w-full max-w-xs"
+                  disabled={configuration.fairnessMode === 'multi_objective'}
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -156,6 +181,89 @@ export function ConfigureStep({ workflowData, setWorkflowData, setFooter }: Step
               <FieldDescription>
                 Early-stops unpromising quantum model trainings to save compute. Kernel and
                 classical models always train to completion.
+              </FieldDescription>
+            </Field>
+          </CardContent>
+        </Card>
+
+        {/* Fairness-aware search */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Fairness-aware search</CardTitle>
+          </CardHeader>
+          <CardContent className="grid items-start gap-x-6 gap-y-4 lg:grid-cols-3">
+            <Field>
+              <FieldLabel htmlFor="fairness-mode">Mode</FieldLabel>
+              <Select
+                value={configuration.fairnessMode}
+                onValueChange={setFairnessMode}
+                disabled={!sensitiveFeature}
+              >
+                <SelectTrigger id="fairness-mode" className="w-full max-w-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="off">Off</SelectItem>
+                  <SelectItem value="constrained">Constrained (threshold)</SelectItem>
+                  <SelectItem value="multi_objective">Multi-objective (Pareto)</SelectItem>
+                </SelectContent>
+              </Select>
+              <FieldDescription>
+                {sensitiveFeature
+                  ? configuration.fairnessMode === 'constrained'
+                    ? 'Deprioritizes trials whose disparity exceeds the threshold (forces the TPE sampler).'
+                    : configuration.fairnessMode === 'multi_objective'
+                      ? 'Searches the F1-vs-disparity Pareto front (disables pruning).'
+                      : `Feeds fairness on "${sensitiveFeature}" back into the search.`
+                  : 'Select a protected attribute in the Features step to enable.'}
+              </FieldDescription>
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="fairness-metric">Disparity metric</FieldLabel>
+              <Select
+                value={configuration.fairnessMetric}
+                onValueChange={(v) => update('fairnessMetric', v)}
+                disabled={!fairnessOn}
+              >
+                <SelectTrigger id="fairness-metric" className="w-full max-w-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="equal_opportunity_difference">
+                    Equal opportunity difference
+                  </SelectItem>
+                  <SelectItem value="disparate_impact">Disparate impact</SelectItem>
+                  <SelectItem value="demographic_parity_difference">
+                    Demographic parity difference
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <FieldDescription>
+                What the search minimizes (multi-objective) or constrains (constrained mode).
+              </FieldDescription>
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="fairness-threshold">Threshold</FieldLabel>
+              <Input
+                id="fairness-threshold"
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                disabled={configuration.fairnessMode !== 'constrained'}
+                placeholder={String(defaultThreshold)}
+                value={configuration.fairnessThreshold ?? ''}
+                onChange={(e) =>
+                  update('fairnessThreshold', e.target.value === '' ? null : Number(e.target.value))
+                }
+                className="max-w-xs"
+              />
+              <FieldDescription>
+                {configuration.fairnessMetric === 'disparate_impact'
+                  ? 'Feasible when the DI ratio is at least this (default 0.8, four-fifths rule).'
+                  : 'Feasible when the disparity is at most this (default 0.1).'}
               </FieldDescription>
             </Field>
           </CardContent>

--- a/frontend/components/optimizer/steps/OptimizeStep.tsx
+++ b/frontend/components/optimizer/steps/OptimizeStep.tsx
@@ -104,6 +104,7 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
           bestParams: finalStatus.best_params,
           trials,
           selectedTrial: prev.optimization.selectedTrial ?? bestTrialNumber,
+          paretoTrials: liveTrialsData?.pareto_trials ?? null,
         },
       }));
       setIsRunning(false);
@@ -143,6 +144,9 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
         categorical_encoding: features.categoricalEncoding,
         sampler: configuration.sampler,
         pruner: configuration.pruner,
+        fairness_mode: configuration.fairnessMode,
+        fairness_metric: configuration.fairnessMetric,
+        fairness_threshold: configuration.fairnessThreshold ?? undefined,
         max_steps: optimizerSettings.maxSteps,
         convergence_interval: optimizerSettings.convergenceInterval,
         max_vmap: optimizerSettings.maxVmap,
@@ -194,6 +198,7 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
               bestValue: trialsData.best_trial?.value ?? prev.optimization.bestValue,
               bestParams: trialsData.best_trial?.params ?? prev.optimization.bestParams,
               selectedTrial: prev.optimization.selectedTrial ?? bestTrialNumber,
+              paretoTrials: trialsData.pareto_trials ?? prev.optimization.paretoTrials,
             },
           }));
         })
@@ -315,6 +320,15 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
             onSelect={hasResults ? selectTrial : undefined}
           />
         </div>
+      )}
+
+      {hasResults && optimization.paretoTrials && optimization.paretoTrials.length > 0 && (
+        <ParetoFrontCard
+          paretoTrials={optimization.paretoTrials}
+          fairnessMetric={configuration.fairnessMetric}
+          selectedTrial={optimization.selectedTrial}
+          onSelect={selectTrial}
+        />
       )}
 
       <div className="grid grid-cols-1 items-start gap-3 xl:grid-cols-2">
@@ -460,6 +474,91 @@ export function OptimizeStep({ workflowData, setWorkflowData, setFooter }: StepP
         )}
       </div>
     </div>
+  );
+}
+
+const METRIC_LABELS: Record<string, string> = {
+  equal_opportunity_difference: 'Equal opportunity difference',
+  disparate_impact: 'Disparity (1 − DI ratio)',
+  demographic_parity_difference: 'Demographic parity difference',
+};
+
+function ParetoFrontCard({
+  paretoTrials,
+  fairnessMetric,
+  selectedTrial,
+  onSelect,
+}: {
+  paretoTrials: Array<{ trial: number; values: number[]; params: Record<string, any> }>;
+  fairnessMetric: string;
+  selectedTrial: number | null;
+  onSelect: (trialNumber: number) => void;
+}) {
+  // Sort by F1 descending; every row is Pareto-optimal (no trial beats it on
+  // both F1 and fairness), so the user picks the trade-off to analyze.
+  const sorted = [...paretoTrials].sort((a, b) => (b.values[0] ?? 0) - (a.values[0] ?? 0));
+  return (
+    <Card size="sm" className="gap-0 py-0">
+      <div className="border-b border-border bg-muted px-3 py-2">
+        <h4 className="text-xs font-semibold text-foreground">
+          Pareto front ({sorted.length} trade-off{sorted.length === 1 ? '' : 's'})
+        </h4>
+        <p className="text-xs text-muted-foreground">
+          Each row is optimal: improving F1 worsens fairness and vice versa. Click a row to analyze
+          that trial.
+        </p>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-10" />
+            <TableHead className="text-right">F1 score</TableHead>
+            <TableHead className="text-right">
+              {METRIC_LABELS[fairnessMetric] ?? 'Disparity'}
+            </TableHead>
+            <TableHead>Model</TableHead>
+            <TableHead className="text-right">Trial</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((t) => {
+            const selected = selectedTrial === t.trial;
+            return (
+              <TableRow
+                key={t.trial}
+                onClick={() => onSelect(t.trial)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSelect(t.trial);
+                  }
+                }}
+                tabIndex={0}
+                aria-selected={selected}
+                className={cn(
+                  'cursor-pointer focus:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand',
+                  selected && 'bg-brand/10 ring-1 ring-inset ring-brand/40 hover:bg-brand/10'
+                )}
+              >
+                <TableCell className="text-center">
+                  {selected && <Check size={16} className="mx-auto text-brand" />}
+                </TableCell>
+                <TableCell className="text-right font-semibold tabular-nums">
+                  {t.values[0]?.toFixed(4)}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{t.values[1]?.toFixed(4)}</TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {t.params?.model_type ?? 'N/A'}
+                </TableCell>
+                <TableCell className="text-right text-xs text-muted-foreground tabular-nums">
+                  #{t.trial}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Card>
   );
 }
 

--- a/frontend/components/optimizer/types.ts
+++ b/frontend/components/optimizer/types.ts
@@ -44,6 +44,17 @@ export interface WorkflowData {
     numTrials: number;
     sampler: 'tpe' | 'random' | 'grid';
     pruner: 'none' | 'asha' | 'hyperband';
+    // Fairness-aware search: constrained (TPE feasibility constraint) or
+    // multi-objective (F1 vs disparity Pareto front). Requires a protected
+    // attribute selected in the Features step.
+    fairnessMode: 'off' | 'constrained' | 'multi_objective';
+    fairnessMetric:
+      | 'equal_opportunity_difference'
+      | 'disparate_impact'
+      | 'demographic_parity_difference';
+    // Difference metrics: feasible when disparity <= threshold (default 0.1).
+    // Disparate impact: feasible when ratio >= threshold (default 0.8).
+    fairnessThreshold: number | null;
   };
   optimization: {
     executionId: string | null;
@@ -54,11 +65,19 @@ export interface WorkflowData {
       trial: number;
       // null for FAILED trials (user_attrs.error records why).
       value: number | null;
+      // Multi-objective runs: [f1, disparity]; null otherwise.
+      values?: number[] | null;
       params: Record<string, any>;
       state?: string;
       user_attrs?: Record<string, any>;
     }>;
     selectedTrial: number | null;
+    // Pareto front of a multi-objective run (values = [f1, disparity]).
+    paretoTrials: Array<{
+      trial: number;
+      values: number[];
+      params: Record<string, any>;
+    }> | null;
   };
   analysis: {
     featureImportance: Array<{ feature: string; importance: number }> | null;
@@ -91,6 +110,9 @@ export const initialWorkflowData: WorkflowData = {
     numTrials: 50,
     sampler: 'tpe',
     pruner: 'none',
+    fairnessMode: 'off',
+    fairnessMetric: 'equal_opportunity_difference',
+    fairnessThreshold: null,
   },
   optimization: {
     executionId: null,
@@ -99,6 +121,7 @@ export const initialWorkflowData: WorkflowData = {
     bestParams: null,
     trials: [],
     selectedTrial: null,
+    paretoTrials: null,
   },
   analysis: {
     featureImportance: null,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -117,6 +117,21 @@ export interface OptimizationRequest {
   max_steps?: number;
   convergence_interval?: number;
   max_vmap?: number;
+  // Fairness-aware search. 'constrained' requires sampler 'tpe';
+  // 'multi_objective' requires pruner 'none'; both require sensitive_feature.
+  fairness_mode?: 'off' | 'constrained' | 'multi_objective';
+  fairness_metric?:
+    | 'equal_opportunity_difference'
+    | 'disparate_impact'
+    | 'demographic_parity_difference';
+  fairness_threshold?: number;
+}
+
+// Pareto-front entry of a multi-objective run; values = [f1, disparity].
+export interface ParetoTrial {
+  trial: number;
+  values: number[];
+  params: Record<string, any>;
 }
 
 export type RunStatus =
@@ -150,6 +165,8 @@ export interface OptimizationTrial {
   trial: number;
   // null for FAILED/PRUNED/RUNNING trials; user_attrs.error records failures.
   value: number | null;
+  // Multi-objective runs: [f1, disparity] for COMPLETE trials.
+  values?: number[] | null;
   params: Record<string, any>;
   state: string;
   user_attrs?: Record<string, any>;
@@ -161,6 +178,7 @@ export interface OptimizationTrial {
 export interface OptimizationTrials {
   trials: OptimizationTrial[];
   best_trial: { value: number; params: Record<string, any> } | null;
+  pareto_trials?: ParetoTrial[] | null;
 }
 
 export async function startOptimization(

--- a/frontend/lib/wizardStorage.ts
+++ b/frontend/lib/wizardStorage.ts
@@ -65,6 +65,10 @@ export function loadWizardState(): WizardState | null {
       ...initialWorkflowData.configuration,
       ...parsed.workflowData.configuration,
     };
+    parsed.workflowData.optimization = {
+      ...initialWorkflowData.optimization,
+      ...parsed.workflowData.optimization,
+    };
     return parsed;
   } catch {
     window.localStorage.removeItem(STORAGE_KEY);

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -12,6 +12,7 @@ from sklearn.metrics import accuracy_score, f1_score
 from quoptuna.backend.models import create_model
 from quoptuna.backend.utils.data_utils.data import load_data, preprocess_data
 from quoptuna.backend.utils.storage import ensure_db_dir, optuna_db_path
+from quoptuna.backend.xai.fairness import FAIRNESS_METRICS, WORST_DISPARITY, compute_disparity
 
 logging.getLogger().setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
@@ -86,6 +87,10 @@ class Optimizer:
         max_steps: Optional[int] = None,  # noqa: FA100
         convergence_interval: Optional[int] = None,  # noqa: FA100
         max_vmap: Optional[int] = None,  # noqa: FA100
+        fairness_mode: str = "off",
+        fairness_metric: str = "equal_opportunity_difference",
+        fairness_threshold: Optional[float] = None,  # noqa: FA100
+        sensitive_test: Optional[np.ndarray] = None,  # noqa: FA100
     ):
         """Initialize the Optimizer class.
 
@@ -114,6 +119,18 @@ class Optimizer:
             max_vmap: Optional override of the ``max_vmap`` search-space entry
                 (circuit evaluations vectorized per JAX call). Must divide the
                 batch size.
+            fairness_mode: "off" (default), "constrained" (single-objective F1
+                with a TPE feasibility constraint on the disparity), or
+                "multi_objective" (maximize F1, minimize disparity; Pareto
+                front returned via ``study.best_trials``).
+            fairness_metric: Disparity metric driving the search — one of
+                ``FAIRNESS_METRICS``.
+            fairness_threshold: Constraint threshold. For difference metrics a
+                trial is feasible when disparity <= threshold (default 0.1);
+                for ``disparate_impact`` feasible when the DI ratio >=
+                threshold (default 0.8, the four-fifths rule).
+            sensitive_test: Sensitive-attribute values aligned positionally
+                with the test split. Required when ``fairness_mode`` != "off".
 
         Attributes:
             db_name: The name of the database.
@@ -159,9 +176,64 @@ class Optimizer:
             # Override the vectorization width without touching other entries;
             # objective() keeps sampling it like any other hyperparameter.
             self.search_space = {**self.search_space, "max_vmap": [max_vmap]}
+        self.fairness_mode = fairness_mode
+        self.fairness_metric = fairness_metric
+        self.sensitive_test = None if sensitive_test is None else np.asarray(sensitive_test).ravel()
+        self._validate_fairness_config()
+        # Normalize the threshold into disparity space once (0 = parity), so
+        # both modes share `disparity <= threshold` semantics: DI's ratio
+        # threshold r becomes 1 - r; difference thresholds pass through.
+        if self.fairness_mode != "off":
+            if fairness_threshold is None:
+                fairness_threshold = 0.8 if self.fairness_metric == "disparate_impact" else 0.1
+            if self.fairness_metric == "disparate_impact":
+                self._disparity_threshold = 1.0 - fairness_threshold
+            else:
+                self._disparity_threshold = fairness_threshold
+        else:
+            self._disparity_threshold = None
+
+    def _validate_fairness_config(self):
+        if self.fairness_mode not in ("off", "constrained", "multi_objective"):
+            msg = (
+                f"Unknown fairness_mode: {self.fairness_mode!r} "
+                "(expected 'off', 'constrained' or 'multi_objective')"
+            )
+            raise ValueError(msg)
+        if self.fairness_mode == "off":
+            return
+        if self.fairness_metric not in FAIRNESS_METRICS:
+            msg = (
+                f"Unknown fairness_metric: {self.fairness_metric!r} "
+                f"(expected one of {FAIRNESS_METRICS})"
+            )
+            raise ValueError(msg)
+        if self.sensitive_test is None:
+            msg = f"fairness_mode={self.fairness_mode!r} requires sensitive_test"
+            raise ValueError(msg)
+        if self.fairness_mode == "constrained" and self.sampler != "tpe":
+            # Random/Grid samplers silently ignore constraints_func; an
+            # experiment must not silently degrade to an unconstrained search.
+            msg = "fairness_mode='constrained' requires sampler='tpe'"
+            raise ValueError(msg)
+        if self.fairness_mode == "multi_objective" and self.pruner != "none":
+            # Optuna raises at trial.report()/should_prune() time for
+            # multi-objective studies; fail at config time instead.
+            msg = "fairness_mode='multi_objective' does not support pruning; set pruner='none'"
+            raise ValueError(msg)
+
+    @staticmethod
+    def _fairness_constraints(trial) -> tuple:
+        # Consulted by TPE for completed trials only; a trial that failed
+        # before recording the attr is treated as maximally infeasible.
+        return tuple(trial.user_attrs.get("fairness_constraint", (WORST_DISPARITY,)))
 
     def _build_sampler(self):
         if self.sampler == "tpe":
+            if self.fairness_mode == "constrained":
+                return TPESampler(
+                    seed=self.sampler_seed, constraints_func=self._fairness_constraints
+                )
             return TPESampler(seed=self.sampler_seed)
         if self.sampler == "random":
             return RandomSampler(seed=self.sampler_seed)
@@ -231,8 +303,9 @@ class Optimizer:
                 trial.set_user_attr(key="converged", value=False)
             score = model.score(self.test_x, self.test_y)
 
-            f_score_ = f1_score(self.test_y, model.predict(self.test_x))
-            acc_ = accuracy_score(self.test_y, model.predict(self.test_x))
+            y_pred = model.predict(self.test_x)
+            f_score_ = f1_score(self.test_y, y_pred)
+            acc_ = accuracy_score(self.test_y, y_pred)
 
             self.log_user_attributes(
                 model_type,
@@ -240,6 +313,26 @@ class Optimizer:
                 trial,
             )
             self._log_resource_attributes(trial, model)
+
+            if self.fairness_mode != "off":
+                try:
+                    disparity = compute_disparity(
+                        self.test_y, y_pred, self.sensitive_test, self.fairness_metric
+                    )
+                except Exception:  # noqa: BLE001 - any metric failure means "maximally unfair"
+                    # e.g. a group with a single class in this trial's
+                    # predictions — score it as maximally unfair, not failed.
+                    logger.warning("Trial %s: fairness computation failed", trial.number)
+                    disparity = WORST_DISPARITY
+                trial.set_user_attr("fairness_disparity", float(disparity))
+                trial.set_user_attr("fairness_metric", self.fairness_metric)
+                if self.fairness_mode == "constrained":
+                    trial.set_user_attr(
+                        "fairness_constraint",
+                        (float(disparity - self._disparity_threshold),),
+                    )
+                if self.fairness_mode == "multi_objective":
+                    return f_score_, float(disparity)
 
             return f_score_  # noqa: TRY300
         except TrialPruned:
@@ -353,6 +446,9 @@ class Optimizer:
         """
         sampler = self._build_sampler()
         pruner = self._build_pruner()
+        directions = (
+            ["maximize", "minimize"] if self.fairness_mode == "multi_objective" else ["maximize"]
+        )
         last_exc: Exception | None = None
         for attempt in range(retries):
             try:
@@ -360,7 +456,7 @@ class Optimizer:
                     storage=self.storage_location,
                     sampler=sampler,
                     pruner=pruner,
-                    directions=["maximize"],
+                    directions=directions,
                     study_name=self.study_name,
                     load_if_exists=True,
                 )

--- a/src/quoptuna/backend/xai/fairness.py
+++ b/src/quoptuna/backend/xai/fairness.py
@@ -17,6 +17,7 @@ from fairlearn.metrics import (
     MetricFrame,
     demographic_parity_difference,
     demographic_parity_ratio,
+    equal_opportunity_difference,
     equalized_odds_difference,
     false_negative_rate,
     false_positive_rate,
@@ -26,6 +27,18 @@ from fairlearn.postprocessing import ThresholdOptimizer
 from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
 
 MAX_SENSITIVE_GROUPS = 20
+
+# Disparity metrics that can drive the fairness-aware search (see
+# ``compute_disparity``). All are scalars where 0.0 means perfect parity.
+FAIRNESS_METRICS = (
+    "equal_opportunity_difference",
+    "disparate_impact",
+    "demographic_parity_difference",
+)
+
+# Assigned when a trial's disparity cannot be computed (e.g. a sensitive group
+# with a single class); also the natural upper bound of every metric above.
+WORST_DISPARITY = 1.0
 
 # Quantum/classical models in this project use labels in {-1, 1}; fairlearn's
 # rate metrics assume a {0, 1} positive class, so map at this boundary.
@@ -84,8 +97,37 @@ def compute_fairness(y_true, y_pred, sensitive: pd.Series) -> dict:
         "equalized_odds_difference": float(
             equalized_odds_difference(yt, yp, sensitive_features=sf)
         ),
+        # Disparate Impact is the selection-rate ratio (four-fifths rule);
+        # kept under its dissertation name alongside demographic_parity_ratio.
+        "disparate_impact": float(demographic_parity_ratio(yt, yp, sensitive_features=sf)),
+        "equal_opportunity_difference": float(
+            equal_opportunity_difference(yt, yp, sensitive_features=sf)
+        ),
     }
     return {"by_group": by_group, "overall": overall, "disparities": disparities}
+
+
+def compute_disparity(y_true, y_pred, sensitive, metric: str) -> float:
+    """Scalar disparity to MINIMIZE during search; 0.0 means perfect parity.
+
+    ``disparate_impact`` (a ratio where 1.0 is parity) is mapped to
+    ``max(0, 1 - ratio)`` so every metric shares the same direction; the
+    difference metrics are returned as-is (fairlearn guarantees them
+    non-negative).
+    """
+    yt, yp = _to_binary(y_true), _to_binary(y_pred)
+    sf = np.asarray(sensitive).ravel()
+    if metric == "equal_opportunity_difference":
+        return float(equal_opportunity_difference(yt, yp, sensitive_features=sf))
+    if metric == "disparate_impact":
+        ratio = float(demographic_parity_ratio(yt, yp, sensitive_features=sf))
+        if np.isnan(ratio):
+            return WORST_DISPARITY
+        return max(0.0, 1.0 - ratio)
+    if metric == "demographic_parity_difference":
+        return float(demographic_parity_difference(yt, yp, sensitive_features=sf))
+    msg = f"Unknown fairness metric: {metric!r}. Expected one of {FAIRNESS_METRICS}."
+    raise ValueError(msg)
 
 
 def plot_group_metrics(fairness: dict, title_prefix: str = "") -> dict[str, str]:

--- a/src/quoptuna/server/api/v1/analysis.py
+++ b/src/quoptuna/server/api/v1/analysis.py
@@ -26,7 +26,11 @@ from quoptuna.server.api.v1.optimize import (
     get_job,
 )
 from quoptuna.server.services.storage import optuna_storage_url
-from quoptuna.server.services.workflow_service import WorkflowExecutor, build_xai
+from quoptuna.server.services.workflow_service import (
+    WorkflowExecutor,
+    build_xai,
+    study_best_trial,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,11 +103,11 @@ def _rehydrate_result(job: dict) -> dict:
     study = load_study(
         storage=optuna_storage_url(request.database_name), study_name=request.study_name
     )
-    best_trial = study.best_trial
+    best_trial = study_best_trial(study)
     result.update(
         {
             "type": "optimization_result",
-            "best_value": best_trial.value,
+            "best_value": best_trial.values[0],
             "best_params": best_trial.params,
             "best_trial_number": best_trial.number,
             "model_name": request.model_name,
@@ -675,10 +679,17 @@ async def generate_study_plots(request: StudyPlotsRequest):
         "timeline": ov.plot_timeline,
     }
 
+    # Multi-objective studies need an explicit target (F1); single-objective
+    # plots reject the kwarg-less form otherwise.
+    plot_kwargs: dict[str, Any] = {}
+    if len(study.directions) > 1:
+        plot_kwargs = {"target": lambda t: t.values[0], "target_name": "F1"}
+
     plots: dict[str, Any] = {}
     for name, func in plot_funcs.items():
         try:
-            fig = cast("Any", func)(study)
+            kwargs = plot_kwargs if name != "timeline" else {}
+            fig = cast("Any", func)(study, **kwargs)
             plots[name] = json.loads(fig.to_json())
         except Exception as exc:
             logger.warning("%s plot failed: %s", name, exc)
@@ -702,7 +713,7 @@ def _resolve_sensitive_series(optimization_id: str, sensitive_feature: Optional[
     row numbers into the raw dataframe (post feature-selection, which only
     selects columns).
     """
-    from quoptuna.server.services import dataset_registry
+    from quoptuna.server.services.sensitive import SensitiveColumnError, resolve_sensitive_series
 
     job = get_job(optimization_id)
     request = OptimizationRequest(**job["request"])
@@ -713,37 +724,13 @@ def _resolve_sensitive_series(optimization_id: str, sensitive_feature: Optional[
             detail="No sensitive_feature provided or stored with this optimization",
         )
 
-    record = dataset_registry.get(request.dataset_id)
-    if not record or not record.get("file_path"):
-        raise HTTPException(status_code=400, detail="Dataset file not found in registry")
-
-    import pandas as pd
-
-    raw_df = pd.read_csv(record["file_path"]).reset_index(drop=True)
-    if column not in raw_df.columns:
-        raise HTTPException(status_code=400, detail=f"Column '{column}' not in dataset")
-
-    x_train = xai.data.get("x_train")
-    n_split = len(x_train) + len(xai.x_test)
-    if len(raw_df) != n_split:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Dataset rows ({len(raw_df)}) do not match the optimization split "
-                f"({n_split}); the dataset file may have changed since the run"
-            ),
+    try:
+        sens_train, sens_test = resolve_sensitive_series(
+            request.dataset_id, column, xai.data.get("x_train"), xai.x_test
         )
-
-    series = raw_df[column]
-    if series.nunique() > MAX_SENSITIVE_GROUPS:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Column '{column}' has {series.nunique()} unique values "
-                f"(max {MAX_SENSITIVE_GROUPS}); pick a categorical column"
-            ),
-        )
-    return column, series.iloc[x_train.index], series.iloc[xai.x_test.index]
+    except SensitiveColumnError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return column, sens_train, sens_test
 
 
 def _compute_fairness_payload(

--- a/src/quoptuna/server/api/v1/optimize.py
+++ b/src/quoptuna/server/api/v1/optimize.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from optuna.trial import TrialState
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from quoptuna.server.services import dataset_registry, run_store
 from quoptuna.server.services.storage import optuna_storage_url
@@ -69,6 +69,31 @@ class OptimizationRequest(BaseModel):
     # Optional override of circuit-evaluation vectorization width; must divide
     # the batch size (32 in the default search space).
     max_vmap: Optional[int] = Field(default=None, ge=1)
+    # Fairness-aware search: "constrained" adds a TPE feasibility constraint on
+    # the disparity; "multi_objective" searches the F1-vs-disparity Pareto front.
+    fairness_mode: Literal["off", "constrained", "multi_objective"] = "off"
+    fairness_metric: Literal[
+        "equal_opportunity_difference", "disparate_impact", "demographic_parity_difference"
+    ] = "equal_opportunity_difference"
+    # Feasibility threshold: difference metrics are feasible when disparity <=
+    # threshold (default 0.1); disparate_impact when the DI ratio >= threshold
+    # (default 0.8, the four-fifths rule).
+    fairness_threshold: Optional[float] = Field(default=None, ge=0, le=1)
+
+    @model_validator(mode="after")
+    def _validate_fairness(self):
+        if self.fairness_mode == "off":
+            return self
+        if not self.sensitive_feature:
+            msg = f"fairness_mode='{self.fairness_mode}' requires sensitive_feature"
+            raise ValueError(msg)
+        if self.fairness_mode == "constrained" and self.sampler != "tpe":
+            msg = "fairness_mode='constrained' requires sampler='tpe' (constraints are TPE-only)"
+            raise ValueError(msg)
+        if self.fairness_mode == "multi_objective" and self.pruner != "none":
+            msg = "fairness_mode='multi_objective' does not support pruning; set pruner='none'"
+            raise ValueError(msg)
+        return self
 
 
 class OptimizationStatus(BaseModel):
@@ -160,6 +185,11 @@ def build_workflow(
                     "max_steps": request.max_steps,
                     "convergence_interval": request.convergence_interval,
                     "max_vmap": request.max_vmap,
+                    "fairness_mode": request.fairness_mode,
+                    "fairness_metric": request.fairness_metric,
+                    "fairness_threshold": request.fairness_threshold,
+                    "sensitive_feature": request.sensitive_feature,
+                    "dataset_id": request.dataset_id,
                 },
             },
         },
@@ -189,7 +219,13 @@ def serialize_study_trials(db_name: str, study_name: str) -> list:
                 "trial": trial.number,
                 # PRUNED trials store their last *intermediate* report as
                 # value; expose None so it is never mistaken for a final F1.
-                "value": trial.value if trial.state == TrialState.COMPLETE else None,
+                # Multi-objective trials have value=None; values[0] is F1.
+                "value": (
+                    trial.values[0] if trial.state == TrialState.COMPLETE and trial.values else None
+                ),
+                "values": list(trial.values)
+                if trial.state == TrialState.COMPLETE and trial.values
+                else None,
                 "params": trial.params,
                 "state": trial.state.name,
                 "user_attrs": trial.user_attrs,
@@ -232,6 +268,7 @@ def run_optimization_background(job_id: str, request: OptimizationRequest):
                 "best_value": opt_result["best_value"],
                 "best_params": opt_result["best_params"],
                 "trials": trials,
+                "pareto_trials": opt_result.get("pareto_trials"),
                 "completed_at": completed_at,
                 "result": opt_result,  # Store full result for SHAP
             }
@@ -429,9 +466,13 @@ async def get_optimization_trials(optimization_id: str):
             # stored value is the last intermediate report, not a final F1.
             is_complete = trial.state == TrialState.COMPLETE
             intermediate = trial.intermediate_values
+            # Multi-objective trials have trial.value=None; values[0] is F1 in
+            # all modes, so "best" below stays "best F1 so far".
+            f1_value = trial.values[0] if is_complete and trial.values else None
             trial_data = {
                 "trial": trial.number,
-                "value": trial.value if is_complete else None,
+                "value": f1_value,
+                "values": list(trial.values) if is_complete and trial.values else None,
                 "params": trial.params,
                 "state": trial.state.name,
                 "user_attrs": trial.user_attrs,
@@ -444,13 +485,9 @@ async def get_optimization_trials(optimization_id: str):
             }
             trials.append(trial_data)
 
-            # Track best (completed trials only)
-            if (
-                is_complete
-                and trial.value is not None
-                and (best_value is None or trial.value > best_value)
-            ):
-                best_value = trial.value
+            # Track best F1 (completed trials only)
+            if f1_value is not None and (best_value is None or f1_value > best_value):
+                best_value = f1_value
                 best_params = trial.params
 
         # Update job with latest data (progress counts finished trials only —
@@ -470,6 +507,7 @@ async def get_optimization_trials(optimization_id: str):
             "best_trial": {"value": best_value, "params": best_params}
             if best_value is not None
             else None,
+            "pareto_trials": job.get("pareto_trials"),
         }
     except Exception:
         # Fallback to stored trials

--- a/src/quoptuna/server/services/sensitive.py
+++ b/src/quoptuna/server/services/sensitive.py
@@ -1,0 +1,55 @@
+"""Resolve a raw dataset's sensitive-attribute column against a train/test split.
+
+``DataPreparation.preprocess`` resets the feature index to a RangeIndex before
+its seeded ``train_test_split``, so split indices are positional row numbers
+into the raw dataframe (post feature-selection, which only selects columns).
+Both the post-hoc fairness audit and the fairness-aware search rely on this
+positional alignment, so it lives here as the single implementation.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from quoptuna.backend.xai.fairness import MAX_SENSITIVE_GROUPS
+from quoptuna.server.services import dataset_registry
+
+
+class SensitiveColumnError(ValueError):
+    """Raised when the sensitive column cannot be resolved or aligned."""
+
+
+def resolve_sensitive_series(
+    dataset_id: str,
+    column: str,
+    x_train: pd.DataFrame,
+    x_test: pd.DataFrame,
+) -> tuple[pd.Series, pd.Series]:
+    """Return the sensitive column split into (train, test) series.
+
+    Raises ``SensitiveColumnError`` with a user-facing message when the dataset
+    is missing, the column is absent, the row counts no longer match the split,
+    or the column has too many unique groups.
+    """
+    record = dataset_registry.get(dataset_id)
+    if not record or not record.get("file_path"):
+        raise SensitiveColumnError("Dataset file not found in registry")
+
+    raw_df = pd.read_csv(record["file_path"]).reset_index(drop=True)
+    if column not in raw_df.columns:
+        raise SensitiveColumnError(f"Column '{column}' not in dataset")
+
+    n_split = len(x_train) + len(x_test)
+    if len(raw_df) != n_split:
+        raise SensitiveColumnError(
+            f"Dataset rows ({len(raw_df)}) do not match the optimization split "
+            f"({n_split}); the dataset file may have changed since the run"
+        )
+
+    series = raw_df[column]
+    if series.nunique() > MAX_SENSITIVE_GROUPS:
+        raise SensitiveColumnError(
+            f"Column '{column}' has {series.nunique()} unique values "
+            f"(max {MAX_SENSITIVE_GROUPS}); pick a categorical column"
+        )
+    return series.iloc[x_train.index], series.iloc[x_test.index]

--- a/src/quoptuna/server/services/workflow_service.py
+++ b/src/quoptuna/server/services/workflow_service.py
@@ -22,6 +22,17 @@ class WorkflowExecutionError(Exception):
     """Raised when workflow execution fails"""
 
 
+def study_best_trial(study):
+    """Best trial for single- or multi-objective studies.
+
+    ``study.best_trial`` raises for multi-objective studies; there we pick the
+    Pareto-front point with the highest F1 (objective 0 in all modes).
+    """
+    if len(study.directions) > 1:
+        return max(study.best_trials, key=lambda t: t.values[0])
+    return study.best_trial
+
+
 def build_xai(
     opt_result: Dict[str, Any],
     trial_number: int | None = None,
@@ -49,7 +60,7 @@ def build_xai(
         if trial is None:
             raise WorkflowExecutionError(f"Trial {trial_number} not found in study")
     else:
-        trial = study.best_trial
+        trial = study_best_trial(study)
 
     params = {k: v for k, v in trial.params.items() if k != "model_type"}
     model = create_model(trial.params["model_type"], **params)
@@ -428,6 +439,11 @@ class WorkflowExecutor:
             "max_steps": config.get("max_steps"),
             "convergence_interval": config.get("convergence_interval"),
             "max_vmap": config.get("max_vmap"),
+            "fairness_mode": config.get("fairness_mode", "off"),
+            "fairness_metric": config.get("fairness_metric", "equal_opportunity_difference"),
+            "fairness_threshold": config.get("fairness_threshold"),
+            "sensitive_feature": config.get("sensitive_feature"),
+            "dataset_id": config.get("dataset_id"),
         }
 
         # Merge input data if available
@@ -461,6 +477,21 @@ class WorkflowExecutor:
             else y_test_df.ravel(),
         }
 
+        # Fairness-aware search needs the raw sensitive column aligned to the
+        # test split (same positional alignment the post-hoc audit uses).
+        fairness_mode = opt_config.get("fairness_mode", "off")
+        sensitive_test = None
+        if fairness_mode != "off":
+            from quoptuna.server.services.sensitive import resolve_sensitive_series
+
+            column = opt_config.get("sensitive_feature")
+            if not column:
+                raise WorkflowExecutionError("Fairness-aware search requires a sensitive_feature")
+            _, sens_test = resolve_sensitive_series(
+                opt_config.get("dataset_id", ""), column, x_train_df, x_test_df
+            )
+            sensitive_test = sens_test.to_numpy()
+
         # Create optimizer (optional reduced search space, e.g. for tests)
         optimizer = Optimizer(
             db_name=opt_config.get("db_name", "workflow_optimization.db"),
@@ -477,6 +508,10 @@ class WorkflowExecutor:
             max_steps=opt_config.get("max_steps"),
             convergence_interval=opt_config.get("convergence_interval"),
             max_vmap=opt_config.get("max_vmap"),
+            fairness_mode=fairness_mode,
+            fairness_metric=opt_config.get("fairness_metric", "equal_opportunity_difference"),
+            fairness_threshold=opt_config.get("fairness_threshold"),
+            sensitive_test=sensitive_test,
         )
 
         # Run optimization
@@ -499,13 +534,25 @@ class WorkflowExecutor:
             raise WorkflowExecutionError(
                 f"All {len(optimizer.study.trials)} trials failed. Last error: {reason}"
             )
-        best_trial = optimizer.study.best_trial
+        best_trial = study_best_trial(optimizer.study)
+
+        pareto_trials = None
+        if len(optimizer.study.directions) > 1:
+            pareto_trials = [
+                {
+                    "trial": t.number,
+                    "values": list(t.values),
+                    "params": t.params,
+                }
+                for t in optimizer.study.best_trials
+            ]
 
         return {
             "type": "optimization_result",
-            "best_value": best_trial.value,
+            "best_value": best_trial.values[0],
             "best_params": best_trial.params,
             "best_trial_number": best_trial.number,
+            "pareto_trials": pareto_trials,
             "study_name": opt_config.get("study_name"),
             "db_name": opt_config.get("db_name"),
             "n_trials": n_trials,
@@ -542,7 +589,7 @@ class WorkflowExecutor:
 
         storage_location = optuna_storage_url(db_name)
         study = load_study(storage=storage_location, study_name=study_name)
-        best_trial = study.best_trial
+        best_trial = study_best_trial(study)
 
         # Get DataFrames from opt_result
         x_train_df = opt_result["x_train"]

--- a/tests/test_fairness_search.py
+++ b/tests/test_fairness_search.py
@@ -1,0 +1,289 @@
+"""Tests for the fairness-aware search (constrained + multi-objective modes).
+
+Follows the ``test_optimizer.py`` pattern: ``create_model`` is stubbed with a
+fake estimator so these exercise the ``Optimizer`` fairness control flow
+(validation, constraint attrs, multi-objective directions) without training.
+"""
+
+import numpy as np
+import optuna
+import pytest
+from pydantic import ValidationError
+
+from quoptuna.backend.tuners import optimizer as optimizer_module
+from quoptuna.backend.tuners.optimizer import Optimizer
+from quoptuna.backend.xai import fairness as fm
+from quoptuna.server.api.v1.optimize import OptimizationRequest
+
+TINY_SEARCH_SPACE = {"C": [1.0]}
+N_TRIALS = 3
+DI_THRESHOLD_DEFAULT = 0.8
+EXPECTED_DISPARITY = 0.5
+N_OBJECTIVES = 2
+
+
+class _BiasedModel:
+    """Predicts +1 for the first half of rows and -1 for the rest, so a
+    sensitive column split the same way yields a deterministic disparity."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def fit(self, _x, _y):
+        return self
+
+    def predict(self, x):
+        n = len(x)
+        return np.array([1] * (n // 2) + [-1] * (n - n // 2))
+
+    def score(self, _x, _y):
+        return 0.5
+
+
+@pytest.fixture
+def tiny_data():
+    rng = np.random.default_rng(0)
+    features = rng.normal(size=(20, 4))
+    labels = np.array([1, -1] * 10)
+    return {
+        "train_x": features,
+        "test_x": features,
+        "train_y": labels,
+        "test_y": labels,
+    }
+
+
+@pytest.fixture
+def sensitive_test():
+    # First half group "a" (all predicted +1), second half "b" (all -1):
+    # maximal demographic-parity disparity.
+    return np.array(["a"] * 10 + ["b"] * 10)
+
+
+@pytest.fixture(autouse=True)
+def _in_tmp_cwd(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def fake_create_model(monkeypatch):
+    monkeypatch.setattr(
+        optimizer_module,
+        "create_model",
+        lambda model_type, **kwargs: _BiasedModel(model_type=model_type, **kwargs),
+    )
+
+
+# --- compute_disparity -------------------------------------------------------
+
+
+def test_compute_disparity_all_metrics():
+    y_true = np.array([1, -1, 1, -1, 1, 1, -1, -1])
+    y_pred = np.array([1, -1, 1, 1, 1, -1, -1, -1])
+    sens = np.array(["a", "a", "a", "a", "b", "b", "b", "b"])
+    # Selection rates: a=0.75, b=0.25 -> DPD 0.5, DI ratio 1/3 -> disparity 2/3.
+    assert (
+        fm.compute_disparity(y_true, y_pred, sens, "demographic_parity_difference")
+        == EXPECTED_DISPARITY
+    )
+    assert fm.compute_disparity(y_true, y_pred, sens, "disparate_impact") == pytest.approx(2 / 3)
+    # TPRs: a=2/2=1.0, b: positives predicted 1 of 2 -> 0.5 -> EOD 0.5.
+    assert (
+        fm.compute_disparity(y_true, y_pred, sens, "equal_opportunity_difference")
+        == EXPECTED_DISPARITY
+    )
+
+
+def test_compute_disparity_zero_when_parity():
+    y = np.array([1, -1, 1, -1])
+    sens = np.array(["a", "a", "b", "b"])
+    for metric in fm.FAIRNESS_METRICS:
+        assert fm.compute_disparity(y, y, sens, metric) == pytest.approx(0.0)
+
+
+def test_compute_disparity_unknown_metric_raises():
+    y = np.array([1, -1])
+    with pytest.raises(ValueError, match="Unknown fairness metric"):
+        fm.compute_disparity(y, y, np.array(["a", "b"]), "accuracy")
+
+
+def test_compute_fairness_includes_di_and_eod():
+    y_true = np.array([1, -1, 1, -1])
+    y_pred = np.array([1, 1, 1, -1])
+    sens = np.array(["a", "a", "b", "b"])
+    disparities = fm.compute_fairness(y_true, y_pred, sens)["disparities"]
+    assert "disparate_impact" in disparities
+    assert "equal_opportunity_difference" in disparities
+    assert disparities["disparate_impact"] == disparities["demographic_parity_ratio"]
+
+
+# --- Optimizer validation ----------------------------------------------------
+
+
+def test_fairness_mode_requires_sensitive_test():
+    with pytest.raises(ValueError, match="requires sensitive_test"):
+        Optimizer(db_name="unit", fairness_mode="constrained")
+
+
+def test_constrained_requires_tpe(sensitive_test):
+    with pytest.raises(ValueError, match="requires sampler='tpe'"):
+        Optimizer(
+            db_name="unit",
+            fairness_mode="constrained",
+            sampler="random",
+            sensitive_test=sensitive_test,
+        )
+
+
+def test_multi_objective_rejects_pruner(sensitive_test):
+    with pytest.raises(ValueError, match="does not support pruning"):
+        Optimizer(
+            db_name="unit",
+            fairness_mode="multi_objective",
+            pruner="asha",
+            sensitive_test=sensitive_test,
+        )
+
+
+def test_unknown_fairness_metric_rejected(sensitive_test):
+    with pytest.raises(ValueError, match="Unknown fairness_metric"):
+        Optimizer(
+            db_name="unit",
+            fairness_mode="constrained",
+            fairness_metric="accuracy",
+            sensitive_test=sensitive_test,
+        )
+
+
+def test_threshold_defaults_are_metric_specific(sensitive_test):
+    diff = Optimizer(db_name="u1", fairness_mode="constrained", sensitive_test=sensitive_test)
+    assert diff._disparity_threshold == pytest.approx(0.1)
+    di = Optimizer(
+        db_name="u2",
+        fairness_mode="constrained",
+        fairness_metric="disparate_impact",
+        sensitive_test=sensitive_test,
+    )
+    # DI ratio threshold 0.8 -> disparity-space threshold 0.2.
+    assert di._disparity_threshold == pytest.approx(1 - DI_THRESHOLD_DEFAULT)
+
+
+# --- constrained mode --------------------------------------------------------
+
+
+def test_constrained_study_records_constraint_attrs(tiny_data, sensitive_test, fake_create_model):
+    opt = Optimizer(
+        db_name="unit_constrained",
+        study_name="constrained_study",
+        data=tiny_data,
+        model_types=["SVC"],
+        search_space=TINY_SEARCH_SPACE,
+        fairness_mode="constrained",
+        fairness_metric="demographic_parity_difference",
+        fairness_threshold=0.1,
+        sensitive_test=sensitive_test,
+    )
+    sampler = opt._build_sampler()
+    assert sampler._constraints_func is not None
+
+    study, _ = opt.optimize(n_trials=N_TRIALS)
+    completed = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    assert len(completed) == N_TRIALS
+    for t in completed:
+        # _BiasedModel selects all of group "a", none of "b" -> disparity 1.0,
+        # violation 1.0 - 0.1 = 0.9 (> 0 means infeasible).
+        assert t.user_attrs["fairness_disparity"] == pytest.approx(1.0)
+        assert t.user_attrs["fairness_constraint"][0] == pytest.approx(0.9)
+        assert t.user_attrs["fairness_metric"] == "demographic_parity_difference"
+
+
+def test_constraints_func_defaults_to_worst_for_missing_attr(sensitive_test):
+    class _Frozen:
+        def __init__(self):
+            self.user_attrs = {}
+
+    assert Optimizer._fairness_constraints(_Frozen()) == (fm.WORST_DISPARITY,)
+
+
+# --- multi-objective mode ----------------------------------------------------
+
+
+def test_multi_objective_study(tiny_data, sensitive_test, fake_create_model):
+    opt = Optimizer(
+        db_name="unit_mo",
+        study_name="mo_study",
+        data=tiny_data,
+        model_types=["SVC"],
+        search_space=TINY_SEARCH_SPACE,
+        fairness_mode="multi_objective",
+        sensitive_test=sensitive_test,
+    )
+    study, best_trials = opt.optimize(n_trials=N_TRIALS)
+    assert len(study.directions) == N_OBJECTIVES
+    assert best_trials
+    completed = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    for t in completed:
+        assert len(t.values) == N_OBJECTIVES
+        assert 0.0 <= t.values[0] <= 1.0
+        assert t.values[1] == t.user_attrs["fairness_disparity"]
+
+
+def test_failed_disparity_scores_worst(tiny_data, sensitive_test, fake_create_model, monkeypatch):
+    def _boom(*_args, **_kwargs):
+        msg = "degenerate group"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(optimizer_module, "compute_disparity", _boom)
+    opt = Optimizer(
+        db_name="unit_worst",
+        study_name="worst_study",
+        data=tiny_data,
+        model_types=["SVC"],
+        search_space=TINY_SEARCH_SPACE,
+        fairness_mode="multi_objective",
+        sensitive_test=sensitive_test,
+    )
+    study, _ = opt.optimize(n_trials=1)
+    (trial,) = study.trials
+    assert trial.user_attrs["fairness_disparity"] == fm.WORST_DISPARITY
+    assert trial.values[1] == fm.WORST_DISPARITY
+
+
+def test_off_mode_unchanged(tiny_data, fake_create_model):
+    opt = Optimizer(
+        db_name="unit_off",
+        study_name="off_study",
+        data=tiny_data,
+        model_types=["SVC"],
+        search_space=TINY_SEARCH_SPACE,
+    )
+    study, _ = opt.optimize(n_trials=1)
+    assert len(study.directions) == 1
+    (trial,) = study.trials
+    assert "fairness_disparity" not in trial.user_attrs
+
+
+# --- request-level validation ------------------------------------------------
+
+
+def test_optimization_request_fairness_validation():
+    base = {
+        "dataset_id": "d",
+        "dataset_source": "upload",
+        "selected_features": ["x"],
+        "target_column": "y",
+        "study_name": "s",
+        "num_trials": 1,
+    }
+    with pytest.raises(ValidationError, match="requires sensitive_feature"):
+        OptimizationRequest(**base, fairness_mode="constrained")
+    with pytest.raises(ValidationError, match="requires sampler='tpe'"):
+        OptimizationRequest(
+            **base, fairness_mode="constrained", sensitive_feature="g", sampler="grid"
+        )
+    with pytest.raises(ValidationError, match="does not support pruning"):
+        OptimizationRequest(
+            **base, fairness_mode="multi_objective", sensitive_feature="g", pruner="hyperband"
+        )
+    ok = OptimizationRequest(**base, fairness_mode="multi_objective", sensitive_feature="g")
+    assert ok.fairness_metric == "equal_opportunity_difference"


### PR DESCRIPTION
What was built

- Metrics (backend/xai/fairness.py): Disparate Impact and Equal Opportunity Difference added to the post-hoc audit (they'll appear in the Analyze fairness tab automatically), plus a new compute_disparity() helper that returns a minimize-direction scalar for the search (DI is mapped to 1 − ratio).
- Search modes (backend/tuners/optimizer.py): a fairness_mode setting with two feedback mechanisms — constrained (F1 objective with a TPE feasibility constraint: trials whose disparity exceeds the threshold are deprioritized) and multi_objective (maximize F1, minimize disparity; returns the Pareto front). Defaults: EOD metric, threshold 0.1 (or 0.8 four-fifths rule for DI). Invalid combos fail fast with clear errors: constrained requires TPE, multi-objective forbids pruning, both require a sensitive column. Failed fairness computation scores a trial as maximally unfair (1.0) rather than failing it.
- Plumbing: new OptimizationRequest fields with a validator (422s with actionable messages), a shared services/sensitive.py that positionally aligns the raw sensitive column to the split (refactored out of the analysis endpoint, now reused by the search), and all study.best_trial/trial.value accesses fixed for multi-objective studies via a study_best_trial() helper. Trials now expose values ([f1, disparity]) alongside value, and study plots pass an F1 target for multi-objective runs.
- UI: a "Fairness-aware search" card in the Configure step (mode/metric/threshold, disabled until a protected attribute is chosen in Features, auto-enforces the sampler/pruner rules), and a Pareto-front table in the Optimize step where you click a trade-off point to send it to the Analyze step.

One limitation to note in the dissertation: per-trial fairness is evaluated on the same test split F1 uses, so there's a mild overfit-to-test concern (consistent with the existing F1 setup). Also, disparity is surfaced in trial user_attrs (fairness_disparity), so if a harsh threshold makes every trial infeasible you can see it in the trials data.

For an end-to-end sanity check when you have time: run one study per mode on a dataset with a protected column (e.g. an adult-income sample) — off as a regression check, constrained with EOD/0.1, and multi_objective with DI, then pick a non-default Pareto trial and confirm the fairness tab shows the new DI/EOD rows.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
