### PR TITLE
Fix: correctness issues and improve multiclass handling in TaskSpec

### DIFF
--- a/src/quoptuna/backend/base/pennylane_models/ovr.py
+++ b/src/quoptuna/backend/base/pennylane_models/ovr.py
@@ -49,6 +49,22 @@ class PlusMinusAdapter(BaseEstimator, ClassifierMixin):
         return (np.asarray(self.estimator_.predict(X)) == 1).astype(int)
 
 
+class ConvergenceAwareOvR(OneVsRestClassifier):
+    """OneVsRestClassifier exposing an aggregated convergence flag.
+
+    Each PlusMinusAdapter swallows its sub-fit's ConvergenceWarning (raising
+    would abort the sibling class fits); ``converged_`` surfaces whether ALL
+    sub-models met the convergence criterion so trial bookkeeping stays honest.
+    """
+
+    @property
+    def converged_(self) -> bool:
+        estimators = getattr(self, "estimators_", None)
+        if not estimators:
+            return True
+        return all(getattr(e, "converged_", True) for e in estimators)
+
+
 def wrap_one_vs_rest(model) -> OneVsRestClassifier:
     """OvR-wrap a {-1,+1} binary estimator for a K>2 target.
 
@@ -59,4 +75,4 @@ def wrap_one_vs_rest(model) -> OneVsRestClassifier:
     from attaching to a wrapper whose K interleaved loss series would not be
     comparable.
     """
-    return OneVsRestClassifier(PlusMinusAdapter(model), n_jobs=1)
+    return ConvergenceAwareOvR(PlusMinusAdapter(model), n_jobs=1)

--- a/src/quoptuna/backend/task_type.py
+++ b/src/quoptuna/backend/task_type.py
@@ -21,6 +21,12 @@ import numpy as np
 
 BINARY_N_CLASSES = 2
 
+# Upper bound on classes for classification. OvR trains one quantum sub-model
+# per class per trial, so an unbounded K (e.g. a continuous column picked as
+# target) would silently burn hours of compute. Keep in sync with the frontend
+# guard (MAX_TARGET_CLASSES in FeaturesStep.tsx).
+MAX_N_CLASSES = 20
+
 
 @dataclass(frozen=True)
 class TaskSpec:
@@ -83,6 +89,12 @@ class TaskSpec:
 
         if n_classes < BINARY_N_CLASSES:
             msg = f"Target must have at least 2 classes, found {n_classes}"
+            raise ValueError(msg)
+        if n_classes > MAX_N_CLASSES:
+            msg = (
+                f"Target has {n_classes} distinct values (max {MAX_N_CLASSES} classes). "
+                "This is likely a continuous column; pick a categorical target."
+            )
             raise ValueError(msg)
 
         if n_classes == BINARY_N_CLASSES:

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -174,6 +174,7 @@ class Optimizer:
         self.max_steps = max_steps
         self.convergence_interval = convergence_interval
         self._disparity_threshold: float | None = None
+        self._warned_pruner_noop = False
         if max_vmap is not None and "max_vmap" in self.search_space:
             # Override the vectorization width without touching other entries;
             # objective() keeps sampling it like any other hyperparameter.
@@ -278,6 +279,16 @@ class Optimizer:
 
     def load_and_preprocess_data(self):
         self.X, self.y = load_data(self.data_path)
+        # Standalone path (no server workflow): derive the task spec from the
+        # raw target so multiclass CSVs get OvR wrapping and macro-F1 instead
+        # of silently keeping the binary defaults (which fails every trial).
+        if self.task_spec is None:
+            from quoptuna.backend.task_type import TaskSpec  # noqa: PLC0415
+
+            spec = TaskSpec.from_target(self.y)
+            self.task_spec = spec.to_dict()
+            self.n_classes = spec.n_classes
+            self.f1_average = "macro" if spec.n_classes > 2 else "binary"  # noqa: PLR2004
         self.train_x, self.test_x, self.train_y, self.test_y = preprocess_data(self.X, self.y)
 
     def objective(self, trial: Trial):
@@ -302,24 +313,39 @@ class Optimizer:
 
             # Iterative (JAX-trained) models report intermediate values so the
             # pruner can stop unpromising trials early. Kernel/sklearn models
-            # have no training steps and simply run to completion.
-            if self.pruner != "none" and hasattr(model, "max_steps"):
-                model.training_callback = self._make_pruning_callback(trial, model)
+            # (and OvR wrappers, whose K interleaved loss series are not
+            # comparable) have no per-step hook and run to completion.
+            if self.pruner != "none":
+                if hasattr(model, "max_steps"):
+                    model.training_callback = self._make_pruning_callback(trial, model)
+                elif self.n_classes > 2 and not self._warned_pruner_noop:  # noqa: PLR2004
+                    self._warned_pruner_noop = True
+                    logger.warning(
+                        "Pruner %r has no effect on OvR-wrapped multiclass models: "
+                        "each trial trains all %d sub-models to completion.",
+                        self.pruner,
+                        self.n_classes,
+                    )
 
             try:
                 model.fit(self.train_x, self.train_y)
-                trial.set_user_attr(key="converged", value=True)
+                # OvR wrappers swallow per-class ConvergenceWarnings and expose
+                # an aggregated flag instead; unwrapped models raise directly.
+                trial.set_user_attr(key="converged", value=bool(getattr(model, "converged_", True)))
             except ConvergenceWarning:
                 # The training loop hit max_steps without meeting the flat-loss
                 # criterion. The partially-trained parameters are still valid —
                 # score the model instead of discarding max_steps of compute.
                 logger.warning("Trial %s did not converge; scoring anyway", trial.number)
                 trial.set_user_attr(key="converged", value=False)
-            score = model.score(self.test_x, self.test_y)
 
+            # Single inference pass: quantum predicts are expensive (K circuit
+            # sweeps per pass for OvR); score/accuracy derive from the same
+            # predictions.
             y_pred = model.predict(self.test_x)
             f_score_ = f1_score(self.test_y, y_pred, average=self.f1_average)
             acc_ = accuracy_score(self.test_y, y_pred)
+            score = acc_
 
             self.log_user_attributes(
                 model_type,

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -311,33 +311,8 @@ class Optimizer:
                 **params,
             )
 
-            # Iterative (JAX-trained) models report intermediate values so the
-            # pruner can stop unpromising trials early. Kernel/sklearn models
-            # (and OvR wrappers, whose K interleaved loss series are not
-            # comparable) have no per-step hook and run to completion.
-            if self.pruner != "none":
-                if hasattr(model, "max_steps"):
-                    model.training_callback = self._make_pruning_callback(trial, model)
-                elif self.n_classes > 2 and not self._warned_pruner_noop:  # noqa: PLR2004
-                    self._warned_pruner_noop = True
-                    logger.warning(
-                        "Pruner %r has no effect on OvR-wrapped multiclass models: "
-                        "each trial trains all %d sub-models to completion.",
-                        self.pruner,
-                        self.n_classes,
-                    )
-
-            try:
-                model.fit(self.train_x, self.train_y)
-                # OvR wrappers swallow per-class ConvergenceWarnings and expose
-                # an aggregated flag instead; unwrapped models raise directly.
-                trial.set_user_attr(key="converged", value=bool(getattr(model, "converged_", True)))
-            except ConvergenceWarning:
-                # The training loop hit max_steps without meeting the flat-loss
-                # criterion. The partially-trained parameters are still valid —
-                # score the model instead of discarding max_steps of compute.
-                logger.warning("Trial %s did not converge; scoring anyway", trial.number)
-                trial.set_user_attr(key="converged", value=False)
+            self._attach_pruning_callback(trial, model)
+            self._fit_and_record_convergence(trial, model)
 
             # Single inference pass: quantum predicts are expensive (K circuit
             # sweeps per pass for OvR); score/accuracy derive from the same
@@ -355,29 +330,9 @@ class Optimizer:
             self._log_resource_attributes(trial, model)
 
             if self.fairness_mode != "off":
-                try:
-                    disparity = compute_disparity(
-                        self.test_y,
-                        y_pred,
-                        self.sensitive_test,
-                        self.fairness_metric,
-                        favorable=self.favorable_label,
-                    )
-                except Exception:  # noqa: BLE001 - any metric failure means "maximally unfair"
-                    # e.g. a group with a single class in this trial's
-                    # predictions — score it as maximally unfair, not failed.
-                    logger.warning("Trial %s: fairness computation failed", trial.number)
-                    disparity = WORST_DISPARITY
-                trial.set_user_attr("fairness_disparity", float(disparity))
-                trial.set_user_attr("fairness_metric", self.fairness_metric)
-                if self.fairness_mode == "constrained":
-                    threshold = self._require_disparity_threshold()
-                    trial.set_user_attr(
-                        "fairness_constraint",
-                        (float(disparity - threshold),),
-                    )
+                disparity = self._record_fairness(trial, y_pred)
                 if self.fairness_mode == "multi_objective":
-                    return f_score_, float(disparity)
+                    return f_score_, disparity
 
             return f_score_  # noqa: TRY300
         except TrialPruned:
@@ -395,6 +350,63 @@ class Optimizer:
             trial.set_user_attr("error", f"{type(e).__name__}: {e}")
             self._log_resource_attributes(trial, model)
             raise
+
+    def _attach_pruning_callback(self, trial: Trial, model) -> None:
+        """Attach the per-step pruning hook where the model supports it.
+
+        Iterative (JAX-trained) models report intermediate values so the
+        pruner can stop unpromising trials early. Kernel/sklearn models (and
+        OvR wrappers, whose K interleaved loss series are not comparable)
+        have no per-step hook and run to completion.
+        """
+        if self.pruner == "none":
+            return
+        if hasattr(model, "max_steps"):
+            model.training_callback = self._make_pruning_callback(trial, model)
+        elif self.n_classes > 2 and not self._warned_pruner_noop:  # noqa: PLR2004
+            self._warned_pruner_noop = True
+            logger.warning(
+                "Pruner %r has no effect on OvR-wrapped multiclass models: "
+                "each trial trains all %d sub-models to completion.",
+                self.pruner,
+                self.n_classes,
+            )
+
+    def _fit_and_record_convergence(self, trial: Trial, model) -> None:
+        """Fit the model, tolerating non-convergence, and record the outcome."""
+        try:
+            model.fit(self.train_x, self.train_y)
+            # OvR wrappers swallow per-class ConvergenceWarnings and expose an
+            # aggregated flag instead; unwrapped models raise directly.
+            trial.set_user_attr(key="converged", value=bool(getattr(model, "converged_", True)))
+        except ConvergenceWarning:
+            # The training loop hit max_steps without meeting the flat-loss
+            # criterion. The partially-trained parameters are still valid —
+            # score the model instead of discarding max_steps of compute.
+            logger.warning("Trial %s did not converge; scoring anyway", trial.number)
+            trial.set_user_attr(key="converged", value=False)
+
+    def _record_fairness(self, trial: Trial, y_pred) -> float:
+        """Compute and record the trial's fairness disparity; return it."""
+        try:
+            disparity = compute_disparity(
+                self.test_y,
+                y_pred,
+                self.sensitive_test,
+                self.fairness_metric,
+                favorable=self.favorable_label,
+            )
+        except Exception:  # noqa: BLE001 - any metric failure means "maximally unfair"
+            # e.g. a group with a single class in this trial's predictions —
+            # score it as maximally unfair, not failed.
+            logger.warning("Trial %s: fairness computation failed", trial.number)
+            disparity = WORST_DISPARITY
+        trial.set_user_attr("fairness_disparity", float(disparity))
+        trial.set_user_attr("fairness_metric", self.fairness_metric)
+        if self.fairness_mode == "constrained":
+            threshold = self._require_disparity_threshold()
+            trial.set_user_attr("fairness_constraint", (float(disparity - threshold),))
+        return float(disparity)
 
     # Validation subset cap for the "accuracy" intermediate metric. Quantum
     # predicts run in max_vmap-sized chunks, so evaluating the full test set at

--- a/src/quoptuna/backend/utils/data_utils/data.py
+++ b/src/quoptuna/backend/utils/data_utils/data.py
@@ -28,13 +28,21 @@ def preprocess_data(x, y):
     """
     Preprocess the data.
     """
+    from quoptuna.backend.task_type import TaskSpec
+
     scaler = StandardScaler()
     x = scaler.fit_transform(x)
+    # Encode via TaskSpec so the label convention matches the rest of the
+    # system: binary class_labels[0] -> -1 / class_labels[1] -> +1, multiclass
+    # -> integer codes 0..K-1 (raw string labels included). Already-encoded
+    # targets ({-1,+1} binary or 0..K-1 codes) pass through unchanged.
     classes = np.unique(y)
-    # Binary targets are encoded to {-1, +1}; multiclass targets pass through
-    # (they are expected to arrive as integer codes 0..K-1).
-    if len(classes) == 2:  # noqa: PLR2004
-        y = np.where(y == classes[0], 1, -1)
+    already_pm = set(np.asarray(classes).tolist()) <= {-1, 1}
+    already_codes = len(classes) > 2 and np.array_equal(  # noqa: PLR2004
+        np.sort(np.asarray(classes)), np.arange(len(classes))
+    )
+    if not (already_pm or already_codes):
+        y = TaskSpec.from_target(y).encode(y)
     return train_test_split(x, y, random_state=42)
 
 

--- a/src/quoptuna/backend/utils/data_utils/data.py
+++ b/src/quoptuna/backend/utils/data_utils/data.py
@@ -9,6 +9,8 @@ from optuna_dashboard import wsgi
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 
+from quoptuna.backend.task_type import TaskSpec
+
 """
 Data utils for loading and preprocessing the data.
 """
@@ -28,8 +30,6 @@ def preprocess_data(x, y):
     """
     Preprocess the data.
     """
-    from quoptuna.backend.task_type import TaskSpec
-
     scaler = StandardScaler()
     x = scaler.fit_transform(x)
     # Encode via TaskSpec so the label convention matches the rest of the

--- a/src/quoptuna/backend/utils/data_utils/prepare.py
+++ b/src/quoptuna/backend/utils/data_utils/prepare.py
@@ -172,15 +172,20 @@ class DataPreparation:
         # Index is a fresh RangeIndex either way, so split indices remain
         # positional row numbers into the raw dataframe.
         classes = np.unique(y)
-        # Labels already encoded to {-1, 1} (e.g. an explicit user mapping applied
-        # upstream) must pass through unchanged — re-encoding would invert them.
-        # Multiclass targets (K>2) also pass through: they arrive pre-encoded to
-        # 0..K-1 codes, and the binary re-encode would silently collapse them.
+        # Labels already encoded to {-1, 1} (e.g. TaskSpec.encode applied
+        # upstream at the split node) must pass through unchanged — re-encoding
+        # would invert them. Multiclass targets (K>2) also pass through: they
+        # arrive pre-encoded to 0..K-1 codes.
         y_values: np.ndarray
         if set(classes.tolist()) <= {-1, 1} or len(classes) != 2:  # noqa: PLR2004
             y_values = np.asarray(y).ravel()
         else:
-            y_values = np.where(np.asarray(y).ravel() == classes[0], 1, -1)
+            # Fallback for direct callers: encode with the SAME convention as
+            # TaskSpec (class_labels[0] -> -1), not the old classes[0] -> +1,
+            # so class naming never inverts relative to a stored spec.
+            from quoptuna.backend.task_type import TaskSpec  # noqa: PLC0415
+
+            y_values = TaskSpec.from_target(y).encode(y)
         y = pd.DataFrame(
             y_values,
             columns=[self.y_col] if not isinstance(self.y_col, list) else self.y_col,

--- a/src/quoptuna/backend/xai/fairness.py
+++ b/src/quoptuna/backend/xai/fairness.py
@@ -3,6 +3,13 @@
 Metrics are computed per sensitive-feature group with ``MetricFrame`` and the
 group plots reuse the same base64 PNG data-URL convention as the SHAP plots so
 they can be surfaced by the API and fed to the LLM report unchanged.
+
+Multiclass targets are audited via the favorable-class framing: predictions
+and labels are binarized to "favorable class vs rest" before any metric is
+computed. Note that ``ThresholdOptimizer`` mitigation is binary-only by
+construction (fairlearn post-processing thresholds a single score); for
+multiclass runs mitigation therefore operates on the binarized favorable
+outcome, not on the full K-class prediction.
 """
 
 from __future__ import annotations

--- a/src/quoptuna/backend/xai/xai.py
+++ b/src/quoptuna/backend/xai/xai.py
@@ -391,11 +391,13 @@ class XAI:
             "recall": self.get_recall,
         }
 
-        try:
-            for key, func in metrics.items():
+        # Per-metric isolation: one failing metric (e.g. roc_curve on a
+        # multiclass proba matrix) must not abort the remaining metrics.
+        for key, func in metrics.items():
+            try:
                 report[key] = func()
-        except (ValueError, TypeError) as e:
-            report[key] = str(e)
+            except (ValueError, TypeError) as e:
+                report[key] = str(e)
         return report
 
     def plot_confusion_matrix(self, plot_config: dict | None = None):

--- a/src/quoptuna/backend/xai/xai.py
+++ b/src/quoptuna/backend/xai/xai.py
@@ -393,11 +393,14 @@ class XAI:
 
         # Per-metric isolation: one failing metric (e.g. roc_curve on a
         # multiclass proba matrix) must not abort the remaining metrics.
-        for key, func in metrics.items():
+        def compute_or_error(func):
             try:
-                report[key] = func()
+                return func()
             except (ValueError, TypeError) as e:
-                report[key] = str(e)
+                return str(e)
+
+        for key, func in metrics.items():
+            report[key] = compute_or_error(func)
         return report
 
     def plot_confusion_matrix(self, plot_config: dict | None = None):

--- a/src/quoptuna/server/api/v1/analysis.py
+++ b/src/quoptuna/server/api/v1/analysis.py
@@ -172,7 +172,10 @@ def _plot_class_index(xai, requested: Optional[int] = None) -> int:
         if getattr(shap_values, "values", None) is None or shap_values.values.ndim <= 2:
             return -1
         classes = list(xai.get_classes())
-        if requested is not None and 0 <= requested < len(classes):
+        # Honor an explicit class only for multiclass: the UI always sends
+        # class_index=0 and hides the picker for binary, so honoring it there
+        # would silently flip binary SHAP plots to the negative class.
+        if len(classes) > 2 and requested is not None and 0 <= requested < len(classes):
             return int(requested)
         return int(classes[-1] if len(classes) <= 2 else classes[0])
     except Exception:
@@ -238,14 +241,22 @@ def _roc_payload(y_test, proba) -> dict[str, Any]:
     from sklearn.metrics import roc_auc_score, roc_curve
 
     fpr, tpr, _ = roc_curve(y_test, proba)
+    # roc_curve on a single-class y returns NaN arrays with only a warning;
+    # NaN in the payload would 500 the whole response (json allow_nan=False).
+    fpr, tpr = np.asarray(fpr), np.asarray(tpr)
+    finite = np.isfinite(fpr) & np.isfinite(tpr)
+    if not finite.any():
+        msg = "ROC curve undefined (evaluation labels contain a single class)"
+        raise ValueError(msg)
+    fpr, tpr = fpr[finite], tpr[finite]
     idx = _downsample_indices(len(fpr))
     try:
         auc = float(roc_auc_score(y_test, proba))
     except Exception:
         auc = None
     return {
-        "fpr": np.asarray(fpr)[idx].tolist(),
-        "tpr": np.asarray(tpr)[idx].tolist(),
+        "fpr": fpr[idx].tolist(),
+        "tpr": tpr[idx].tolist(),
         "auc": auc,
     }
 
@@ -267,11 +278,16 @@ def _pr_payload(y_test, proba) -> dict[str, Any]:
     }
 
 
-def _per_class_curve_payloads(y_test, proba, spec: dict) -> tuple[dict, dict]:
+def _per_class_curve_payloads(y_test, proba, spec: dict, model_classes=None) -> tuple[dict, dict]:
     """One-vs-rest ROC and PR payloads per class for a multiclass task.
 
     Binarizes the encoded labels per class and reuses the binary payload
     helpers on each (indicator, class-probability-column) pair.
+
+    ``model_classes`` (the fitted model's ``classes_``) maps encoded class
+    codes to probability columns: models fit their class list from y_train,
+    so a class absent from the (unstratified) train split shifts every later
+    proba column. Without the mapping we'd attribute curves to wrong names.
     """
     from sklearn.preprocessing import label_binarize
 
@@ -280,15 +296,28 @@ def _per_class_curve_payloads(y_test, proba, spec: dict) -> tuple[dict, dict]:
     names = _spec_display_labels(spec, encoded)
     proba = np.asarray(proba)
     y_bin = label_binarize(np.asarray(y_test).ravel(), classes=encoded)
+    col_of = {int(c): i for i, c in enumerate(model_classes)} if model_classes is not None else None
 
     roc_classes, pr_classes = [], []
     for k in range(n_classes):
+        col = col_of.get(k) if col_of is not None else k
+        if col is None or col >= proba.shape[1]:
+            logger.warning(
+                "No probability column for class %s (absent from training data); skipping",
+                names[k],
+            )
+            continue
+        if len(np.unique(y_bin[:, k])) < 2:
+            logger.warning(
+                "Class %s absent from the evaluation subset; skipping its curves", names[k]
+            )
+            continue
         try:
-            roc_classes.append({"label": names[k], **_roc_payload(y_bin[:, k], proba[:, k])})
+            roc_classes.append({"label": names[k], **_roc_payload(y_bin[:, k], proba[:, col])})
         except Exception as exc:
             logger.warning("ROC curve failed for class %s: %s", names[k], exc)
         try:
-            pr_classes.append({"label": names[k], **_pr_payload(y_bin[:, k], proba[:, k])})
+            pr_classes.append({"label": names[k], **_pr_payload(y_bin[:, k], proba[:, col])})
         except Exception as exc:
             logger.warning("PR curve failed for class %s: %s", names[k], exc)
 
@@ -618,7 +647,10 @@ async def generate_curves(request: MetricsRequest):
     if multiclass_spec is not None:
         # One-vs-rest: one line per class on each plot.
         roc_data, pr_data = _per_class_curve_payloads(
-            y_test, xai.predictions_proba, multiclass_spec
+            y_test,
+            xai.predictions_proba,
+            multiclass_spec,
+            model_classes=getattr(xai.model, "classes_", None),
         )
         roc_auc = roc_data.get("macro_auc")
         try:
@@ -740,7 +772,12 @@ async def generate_curves_data(request: MetricsRequest):
     pr = None
     if multiclass_spec is not None:
         try:
-            roc, pr = _per_class_curve_payloads(y_test, xai.predictions_proba, multiclass_spec)
+            roc, pr = _per_class_curve_payloads(
+                y_test,
+                xai.predictions_proba,
+                multiclass_spec,
+                model_classes=getattr(xai.model, "classes_", None),
+            )
         except Exception as exc:
             logger.warning("Multiclass curve data failed: %s", exc)
     else:

--- a/src/quoptuna/server/services/headless.py
+++ b/src/quoptuna/server/services/headless.py
@@ -192,7 +192,10 @@ def run_headless_optimization(
         if multiclass:
             try:
                 roc, pr = analysis_mod._per_class_curve_payloads(  # noqa: SLF001
-                    xai.y_test, xai.predictions_proba, spec
+                    xai.y_test,
+                    xai.predictions_proba,
+                    spec,
+                    model_classes=getattr(xai.model, "classes_", None),
                 )
                 curves = {
                     "per_class_auc": {c["label"]: c["auc"] for c in roc["per_class"]},
@@ -216,13 +219,28 @@ def run_headless_optimization(
                 _, sens_test = resolve_sensitive_series(
                     dataset_id, sensitive_feature, xai.data.get("x_train"), xai.x_test
                 )
-                favorable = (
-                    int(spec["favorable_code"])
-                    if multiclass and spec and spec.get("favorable_code") is not None
-                    else 1
-                )
-                fair = compute_fairness(xai.y_test, pred, sens_test, favorable=favorable)
-                summary["analysis"]["fairness_disparities"] = fair["disparities"]
+                # Mirror the API guard (_compute_fairness_payload): a multiclass
+                # audit is meaningless without a designated favorable class —
+                # falling back to code 1 would silently audit an arbitrary class.
+                if multiclass and (not spec or spec.get("favorable_code") is None):
+                    summary["analysis"]["fairness_disparities"] = (
+                        "skipped: multiclass fairness requires --favorable-class"
+                    )
+                else:
+                    favorable = (
+                        int(spec["favorable_code"])
+                        if multiclass and spec and spec.get("favorable_code") is not None
+                        else 1
+                    )
+                    fair = compute_fairness(xai.y_test, pred, sens_test, favorable=favorable)
+                    summary["analysis"]["fairness_disparities"] = fair["disparities"]
+                    if spec:
+                        # Disclose which class was audited as the favorable outcome.
+                        labels_list = [str(c) for c in spec.get("class_labels", [])]
+                        if multiclass and 0 <= favorable < len(labels_list):
+                            summary["analysis"]["fairness_favorable_class"] = labels_list[favorable]
+                        elif not multiclass and len(labels_list) == 2:
+                            summary["analysis"]["fairness_favorable_class"] = labels_list[1]
             except Exception as exc:
                 summary["analysis"]["fairness_disparities"] = f"failed: {exc}"
 

--- a/src/quoptuna/server/services/workflow_service.py
+++ b/src/quoptuna/server/services/workflow_service.py
@@ -296,18 +296,23 @@ class WorkflowExecutor:
             label_mapping=label_mapping,
             favorable_class=config.get("favorable_class"),
         )
-        if label_mapping and task_spec.kind == "binary":
+        # ALWAYS encode via the spec — binary with or without an explicit
+        # mapping, and multiclass. Leaving unmapped binary targets to
+        # DataPreparation's legacy encoder (classes[0] -> +1) inverts the
+        # sign convention relative to the stored spec (class_labels[0] -> -1),
+        # silently swapping class names in every downstream consumer.
+        if task_spec.kind == "binary":
+            derived = "" if label_mapping else " (derived; no explicit mapping)"
             logger.info(
-                f"Applying label mapping at split: {label_mapping.get('neg')} -> -1, "
-                f"{label_mapping.get('pos')} -> 1"
+                f"Encoding binary target at split: {task_spec.class_labels[0]} -> -1, "
+                f"{task_spec.class_labels[1]} -> 1{derived}"
             )
-            y = pd.Series(task_spec.encode(y), name=data["y_column"])
-        elif task_spec.is_multiclass:
+        else:
             logger.info(
                 f"Multiclass target ({task_spec.n_classes} classes): encoding "
                 f"{list(task_spec.class_labels)} -> 0..{task_spec.n_classes - 1}"
             )
-            y = pd.Series(task_spec.encode(y), name=data["y_column"])
+        y = pd.Series(task_spec.encode(y), name=data["y_column"])
 
         # Use DataPreparation class
         data_prep = DataPreparation(

--- a/tests/test_multiclass.py
+++ b/tests/test_multiclass.py
@@ -149,7 +149,9 @@ class TestCreateModelMulticlass:
             max_steps=10,
             convergence_interval=5,
         )
-        assert type(model).__name__ == "OneVsRestClassifier"
+        from sklearn.multiclass import OneVsRestClassifier  # noqa: PLC0415
+
+        assert isinstance(model, OneVsRestClassifier)
         # Pruning callback gate: the wrapper must not expose max_steps.
         assert not hasattr(model, "max_steps")
 
@@ -252,3 +254,115 @@ class TestFavorableBinarization:
             y_true, y_pred, sensitive, "demographic_parity_difference", favorable=2
         )
         assert disparity == pytest.approx(1.0)
+
+
+class TestReviewFixes:
+    """Regression tests for the multi-class review findings."""
+
+    def test_task_spec_rejects_high_cardinality_target(self):
+        from quoptuna.backend.task_type import MAX_N_CLASSES  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="max"):
+            TaskSpec.from_target(np.arange(MAX_N_CLASSES + 1))
+
+    def test_preprocess_data_binary_matches_taskspec_convention(self):
+        """classes[0] must map to -1 (TaskSpec convention), not +1."""
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=(40, 3))
+        y = np.array(["no", "yes"] * 20)
+        _, _, train_y, test_y = preprocess_data(x, y)
+        all_y = np.concatenate([np.ravel(train_y), np.ravel(test_y)])
+        # 'no' (sorted first) -> -1, 'yes' -> +1; balanced input stays balanced.
+        assert set(all_y.tolist()) == {-1, 1}
+        assert (all_y == 1).sum() == 20  # noqa: PLR2004
+
+    def test_preprocess_data_multiclass_encodes_raw_labels(self):
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=(30, 3))
+        y = np.array(["a", "b", "c"] * 10)
+        _, _, train_y, test_y = preprocess_data(x, y)
+        all_y = np.concatenate([np.ravel(train_y), np.ravel(test_y)])
+        assert set(all_y.tolist()) == {0, 1, 2}
+
+    def test_data_preparation_binary_matches_taskspec_convention(self):
+        from quoptuna.backend.utils.data_utils.prepare import DataPreparation  # noqa: PLC0415
+
+        df_x = pd.DataFrame({"f": np.linspace(0, 1, 20)})
+        df_y = pd.Series(["neg_class", "pos_class"] * 10, name="t")
+        prep = DataPreparation(dataset={"x": df_x, "y": df_y}, x_cols=["f"], y_col="t")
+        _, _, y_train, y_test = prep.prepare_data()
+        all_y = np.concatenate([np.ravel(y_train), np.ravel(y_test)])
+        assert (all_y == 1).sum() == 10  # noqa: PLR2004  # 'pos_class' (sorted second) -> +1
+
+    def test_ovr_wrapper_exposes_aggregated_converged_flag(self):
+        from sklearn.linear_model import Perceptron  # noqa: PLC0415
+
+        from quoptuna.backend.base.pennylane_models.ovr import wrap_one_vs_rest  # noqa: PLC0415
+
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=(30, 3))
+        y = np.array([0, 1, 2] * 10)
+        model = wrap_one_vs_rest(Perceptron())
+        # Perceptron never raises ConvergenceWarning as exception -> converged
+        # (adapters default converged_=True when no warning fired).
+        model.fit(x, y)
+        assert model.converged_ is True
+
+    def test_get_report_isolates_metric_failures(self):
+        """One failing metric must not abort later metrics (multiclass report)."""
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from quoptuna.backend.xai.xai import XAI  # noqa: PLC0415
+
+        xai = MagicMock(spec=XAI)
+        xai.get_confusion_matrix.side_effect = ValueError("boom")
+        xai.get_classification_report.return_value = "ok"
+        xai.get_roc_curve.side_effect = ValueError("multiclass not supported")
+        xai.get_mcc.return_value = 0.5
+        for name in (
+            "get_roc_auc_score",
+            "get_precision_recall_curve",
+            "get_average_precision_score",
+            "get_f1_score",
+            "get_log_loss",
+            "get_cohens_kappa",
+            "get_precision",
+            "get_recall",
+        ):
+            getattr(xai, name).return_value = 0.1
+        report = XAI.get_report(xai)
+        assert report["mcc"] == 0.5  # noqa: PLR2004  # computed despite earlier failures
+        assert report["confusion_matrix"] == "boom"
+
+    def test_per_class_curves_skip_absent_class_without_nan(self):
+        from quoptuna.server.api.v1.analysis import _per_class_curve_payloads  # noqa: PLC0415
+
+        rng = np.random.default_rng(0)
+        # Class 2 never appears in y_test; proba has only 2 columns (model
+        # trained without class 2), model_classes maps codes 0 and 1.
+        y_test = np.array([0, 1] * 15)
+        proba = rng.uniform(size=(30, 2))
+        proba = proba / proba.sum(axis=1, keepdims=True)
+        spec = {"kind": "multiclass", "n_classes": 3, "class_labels": ["a", "b", "c"]}
+        roc, _pr = _per_class_curve_payloads(y_test, proba, spec, model_classes=[0, 1])
+        labels = [c["label"] for c in roc["per_class"]]
+        assert "c" not in labels  # absent class skipped, not misattributed
+        for c in roc["per_class"]:
+            assert all(np.isfinite(c["fpr"])), "NaN leaked into ROC payload"
+        assert roc["macro_auc"] is None  # incomplete class coverage -> no macro
+
+    def test_plot_class_index_ignores_requested_for_binary(self):
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from quoptuna.server.api.v1.analysis import _plot_class_index  # noqa: PLC0415
+
+        xai = MagicMock()
+        values = MagicMock()
+        values.values = np.zeros((5, 3, 2))  # per-class SHAP, binary
+        xai.shap_values = values
+        xai.get_classes.return_value = [0, 1]
+        # UI always sends 0; binary must keep the positive class regardless.
+        assert _plot_class_index(xai, requested=0) == 1
+        xai.get_classes.return_value = [0, 1, 2]
+        values.values = np.zeros((5, 3, 3))
+        assert _plot_class_index(xai, requested=2) == 2  # noqa: PLR2004


### PR DESCRIPTION
All 10 findings are fixed, tested, and green. Summary of what changed:

Correctness fixes
1. Label inversion — the split node now always encodes via TaskSpec.encode (binary with or without a mapping), and the two legacy fallback encoders (DataPreparation.preprocess, preprocess_data) were rewritten to use the same TaskSpec convention, so classes[0]→−1 everywhere. One convention, one encoder.
2. Binary SHAP flip — _plot_class_index only honors an explicit class_index for multiclass; binary keeps the positive-class default, restoring pre-branch behavior.
3. NaN → 500 curves — non-finite ROC points are filtered, undefined curves raise cleanly into the per-class skip path, and classes absent from the evaluation subset are skipped with a log warning.
4. Standalone/Streamlit multiclass — load_and_preprocess_data now derives a TaskSpec from the raw target (macro-F1 + OvR wrapping engage), and preprocess_data encodes raw multiclass labels to 0..K−1.
5. Multiclass report missing metrics — get_report now isolates each metric in its own try/except; MCC, log loss, and Cohen's kappa reach the LLM.
6. CLI fairness fallback — mirrors the API guard ("skipped: multiclass fairness requires --favorable-class") and discloses which class was audited.
7. Proba column misalignment — per-class curves map class codes through the fitted model's classes_ at all three call sites.
8. OvR converged=True — new ConvergenceAwareOvR aggregates sub-model convergence; the optimizer records the honest flag. Also added a one-time log warning when a pruner is configured but can't apply to OvR trials.
9. Class-count cap — TaskSpec.from_target rejects >20 classes with a clear message, matching the frontend cap.
10. Double inference — one predict pass per trial; score derives from the same predictions (halves test-set circuit cost, ×K for OvR).

Also added the ThresholdOptimizer binary-only limitation to fairness.py's module docs (your dissertation-documentation item), plus 8 regression tests pinning the fixes. Full fast suite: 161 passed, ruff clean on all touched files.

Not fixed (lower-priority confirmed findings from the review, flagging for later): the headless CLI's double-fit fallback for no-proba models, CLI runs not registering in run_store (invisible on /runs), and the cleanup-tier items (TaskSpec dict-poking across endpoints, duplicated best-trial logic, ROC/PR card clones).
