### PR TITLE
feat: Migrate to SQLModel and add S3 artifact storage support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,19 @@
 # Copy to .env and fill in the values from your Auth0 application settings.
 # Auth is enforced only when all four AUTH0_* values are set.
 AUTH0_DOMAIN=qentora-quoptuna.us.auth0.com
+DATABASE_URL=sqlite:///./quoptuna.db
+# Set both DATABASE_URL and OPTUNA_DATABASE_URL to PostgreSQL/Supabase in deployment.
+OPTUNA_DATABASE_URL=
+OPTUNA_DB_SCHEMA=optuna
+ARTIFACT_STORAGE=local
+ARTIFACT_ROOT=db/analysis
+S3_ENDPOINT_URL=
+S3_BUCKET=
+S3_REGION=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_PREFIX=quoptuna
+S3_SIGNED_URL_TTL=900
 AUTH0_CLIENT_ID=wyLowEr4n0koWzsFL9YaMAiTFyLWZWH4
 AUTH0_CLIENT_SECRET=
 

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy to .env and fill in the values from your Auth0 application settings.
 # Auth is enforced only when all four AUTH0_* values are set.
 AUTH0_DOMAIN=qentora-quoptuna.us.auth0.com
-DATABASE_URL=sqlite:///./quoptuna.db
+DATABASE_URL=sqlite:///./db/quoptuna_app.db
 # Set both DATABASE_URL and OPTUNA_DATABASE_URL to PostgreSQL/Supabase in deployment.
 OPTUNA_DATABASE_URL=
 OPTUNA_DB_SCHEMA=optuna

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,8 @@ services:
       - ./src:/quoptuna/src
       - ./uploads:/app/uploads
     environment:
-      - DATABASE_URL=sqlite:///./quoptuna.db
+      - DATABASE_URL=sqlite:///./db/quoptuna_app.db
+      - OPTUNA_DB_SCHEMA=optuna
       - CORS_ORIGINS=http://localhost:3000,http://localhost:5173
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig({
             { slug: "how-to/run-fairness-aware-search" },
             { slug: "how-to/use-multiclass" },
             { slug: "how-to/generate-reports" },
+            { slug: "how-to/migrate-to-supabase" },
             { slug: "how-to/deploy-this-site" },
           ],
         },

--- a/docs-site/src/content/docs/how-to/migrate-to-supabase.md
+++ b/docs-site/src/content/docs/how-to/migrate-to-supabase.md
@@ -1,0 +1,142 @@
+---
+title: Move persistence to Supabase and S3
+description: Configure PostgreSQL application metadata, Optuna studies, and S3-compatible artifacts.
+---
+
+This guide moves QuOptuna's durable data out of local SQLite files.
+
+## Install the deployment dependencies
+
+```bash
+uv sync
+```
+
+## Configure the environment
+
+Copy `.env.example` to `.env`, then set your Supabase PostgreSQL connection:
+
+```dotenv
+DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOST:5432/postgres
+OPTUNA_DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOST:5432/postgres
+OPTUNA_DB_SCHEMA=optuna
+```
+
+`DATABASE_URL` stores QuOptuna application data such as runs, sessions,
+datasets, analysis snapshots, and reports. `OPTUNA_DATABASE_URL` stores Optuna
+studies and trials. They may point to the same Supabase database; QuOptuna
+places Optuna tables in the separate `optuna` schema.
+
+## Migrate application metadata
+
+Preview the migration:
+
+```bash
+uv run quoptuna migrate-supabase \
+  --source-db db/quoptuna_app.db \
+  --database-url "$DATABASE_URL" \
+  --dry-run
+```
+
+Run it after reviewing the counts:
+
+```bash
+uv run quoptuna migrate-supabase \
+  --source-db db/quoptuna_app.db \
+  --database-url "$DATABASE_URL"
+```
+
+The local database remains available as a backup.
+
+## Migrate the active Optuna database
+
+Identify the database used by the runs, then migrate that file. For example:
+
+```bash
+uv run quoptuna migrate-optuna db/results-trial-june15.db
+```
+
+The command migrates every study in that file. Use `--study-name` when only one
+study is needed. It copies trials, parameters, values, states, and study/trial
+attributes.
+
+## Configure S3-compatible artifacts
+
+To store analysis images and uploaded datasets remotely:
+
+```dotenv
+ARTIFACT_STORAGE=s3
+S3_ENDPOINT_URL=https://YOUR-S3-ENDPOINT
+S3_BUCKET=YOUR-BUCKET
+S3_REGION=YOUR-REGION
+S3_ACCESS_KEY_ID=YOUR-ACCESS-KEY
+S3_SECRET_ACCESS_KEY=YOUR-SECRET-KEY
+S3_PREFIX=quoptuna
+S3_SIGNED_URL_TTL=900
+```
+
+For AWS S3, leave `S3_ENDPOINT_URL` empty. For Supabase Storage or MinIO, use
+the provider's S3-compatible endpoint. Create the bucket before starting the
+server.
+
+## Verify the migration
+
+Start the server:
+
+```bash
+uv run quoptuna run --no-browser
+```
+
+Create a new run and analysis, then confirm application records in Supabase:
+
+```sql
+select job_id, session_id, study_name, status
+from public.quoptuna_runs
+order by created_at desc;
+```
+
+Confirm Optuna tables are isolated in the configured schema:
+
+```sql
+select table_schema, table_name
+from information_schema.tables
+where table_schema = 'optuna'
+order by table_name;
+```
+
+If S3 is enabled, check that objects appear under:
+
+```text
+quoptuna/runs/<run-id>/analysis/<snapshot-id>/revisions/<revision>/
+```
+
+Restart the server and reopen the run. Successful rehydration confirms that
+the run metadata is coming from Supabase and analysis artifacts are coming from
+the configured object storage.
+
+## Troubleshooting
+
+### `No module named psycopg2`
+
+Use the `psycopg` URL form and reinstall dependencies:
+
+```bash
+uv sync
+```
+
+The URL should be accepted as either `postgresql://...` or
+`postgresql+psycopg://...`; QuOptuna normalizes the former.
+
+### `copy_study() got an unexpected keyword argument study_name`
+
+Use the current CLI command from this version. It uses Optuna's
+`to_study_name` API internally:
+
+```bash
+uv run quoptuna migrate-optuna db/results-trial-june15.db
+```
+
+### A study already exists
+
+The source may have been partially migrated. Inspect the destination before
+rerunning; do not delete the source SQLite database until the trial counts have
+been verified.

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -3,7 +3,56 @@ title: CLI reference
 description: The quoptuna command-line interface — the run and optimize subcommands and their options.
 ---
 
-The `quoptuna` command is a [Typer](https://typer.tiangolo.com/) application with two subcommands. Invoking `quoptuna` with no subcommand is equivalent to `quoptuna run`.
+The `quoptuna` command is a [Typer](https://typer.tiangolo.com/) application. Invoking `quoptuna` with no subcommand is equivalent to `quoptuna run`.
+
+## `quoptuna migrate-supabase`
+
+Copy application metadata from the legacy SQLite `quoptuna_app.db` into the
+configured SQLModel database. The source file is not deleted.
+
+```bash
+quoptuna migrate-supabase \
+  --source-db db/quoptuna_app.db \
+  --database-url "$DATABASE_URL" \
+  --dry-run
+
+quoptuna migrate-supabase \
+  --source-db db/quoptuna_app.db \
+  --database-url "$DATABASE_URL"
+```
+
+`--dry-run` reports the records that would be copied. The command is safe to
+repeat and uses stable IDs when writing the destination.
+
+## `quoptuna migrate-optuna`
+
+Copy all Optuna studies from one local SQLite database into the PostgreSQL
+database configured by `OPTUNA_DATABASE_URL`:
+
+```bash
+quoptuna migrate-optuna db/results-trial-june15.db
+```
+
+Copy only one study:
+
+```bash
+quoptuna migrate-optuna \
+  db/results-trial-june15.db \
+  --study-name heart-june16-trial3
+```
+
+Override the configured destination:
+
+```bash
+quoptuna migrate-optuna \
+  db/results-trial-june15.db \
+  --target-url "$OPTUNA_DATABASE_URL"
+```
+
+The command copies study metadata and trials, does not delete the source file,
+and reports each migrated study. Existing studies with the same name can cause
+Optuna to reject a repeat; verify the destination before rerunning a partially
+completed migration.
 
 ## `quoptuna run`
 

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -9,13 +9,51 @@ Settings can be supplied via a `.env` file or the process environment.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `DATABASE_URL` | `sqlite:///./quoptuna.db` | Application database URL |
+| `DATABASE_URL` | `sqlite:///./db/quoptuna_app.db` | SQLModel application database URL; use `postgresql+psycopg://...` for Supabase |
+| `OPTUNA_DATABASE_URL` | empty | PostgreSQL/Supabase URL for Optuna studies; falls back to local SQLite when empty |
+| `OPTUNA_DB_SCHEMA` | `optuna` | PostgreSQL schema used for Optuna tables |
 | `UPLOAD_DIR` | `./uploads` | Directory for uploaded datasets |
 | `MAX_UPLOAD_SIZE` | 100 MB | Maximum upload size |
 | `DEFAULT_N_TRIALS` | `100` | Default number of Optuna trials |
 | `DEFAULT_TIMEOUT` | `3600` s | Default run timeout |
 | `CORS_ORIGINS` | — | Comma-separated list of allowed origins |
 | `APP_BASE_URL` | `http://localhost:8000` | Base URL for generated links |
+
+## Artifact and dataset storage
+
+Analysis images and uploaded datasets use local files by default. Set
+`ARTIFACT_STORAGE=s3` to use AWS S3, Supabase Storage's S3-compatible endpoint,
+MinIO, or another compatible provider.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ARTIFACT_STORAGE` | `local` | `local` or `s3` |
+| `ARTIFACT_ROOT` | `db/analysis` | Local artifact directory |
+| `S3_ENDPOINT_URL` | empty | S3-compatible endpoint; empty for AWS S3 |
+| `S3_BUCKET` | empty | Bucket name |
+| `S3_REGION` | empty | Provider region |
+| `S3_ACCESS_KEY_ID` | empty | S3 access key; keep server-side only |
+| `S3_SECRET_ACCESS_KEY` | empty | S3 secret; keep server-side only |
+| `S3_PREFIX` | `quoptuna` | Object-key prefix |
+| `S3_SIGNED_URL_TTL` | `900` | Signed URL lifetime in seconds |
+
+## Supabase example
+
+```dotenv
+DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOST:5432/postgres
+OPTUNA_DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOST:5432/postgres
+OPTUNA_DB_SCHEMA=optuna
+ARTIFACT_STORAGE=s3
+S3_ENDPOINT_URL=https://YOUR-S3-ENDPOINT
+S3_BUCKET=YOUR-BUCKET
+S3_REGION=YOUR-REGION
+S3_ACCESS_KEY_ID=YOUR-ACCESS-KEY
+S3_SECRET_ACCESS_KEY=YOUR-SECRET-KEY
+S3_PREFIX=quoptuna
+```
+
+Never commit this file with real credentials. The backend uses these credentials;
+the browser should never receive them.
 
 ## LLM report providers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quoptuna"
-version = "0.1.3"
+version = "0.1.4"
 description = "Fairness-aware, explainable AutoML for quantum and classical machine learning, powered by Optuna and PennyLane."
 authors = [
     {name = "Edwin Jose", email = "edwinjose900@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dependencies = [
     "fairlearn>=0.11.0",
     "openai-agents[litellm]>=0.0.16",
     "auth0-server-python>=1.0.0b1,<2",
+    "sqlmodel>=0.0.22,<0.1.0",
+    "psycopg[binary]>=3.2.0,<4.0.0",
+    "boto3>=1.35.0,<2.0.0",
 ]
 readme = "README.md"
 classifiers = [

--- a/src/quoptuna/backend/utils/storage.py
+++ b/src/quoptuna/backend/utils/storage.py
@@ -10,6 +10,7 @@ that exists on disk.
 
 from pathlib import Path
 from urllib.parse import quote, urlparse, urlunparse
+
 from quoptuna.server.core.config import settings
 
 DB_DIR = Path("db")
@@ -66,7 +67,8 @@ def ensure_optuna_schema() -> None:
     if not url.startswith(("postgresql://", "postgresql+")):
         return
     from sqlalchemy import create_engine, text  # noqa: PLC0415
+
     engine = create_engine(url)
     with engine.begin() as connection:
         schema = settings.OPTUNA_DB_SCHEMA.replace('"', '""')
-        connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))  # noqa: S608
+        connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))

--- a/src/quoptuna/backend/utils/storage.py
+++ b/src/quoptuna/backend/utils/storage.py
@@ -9,6 +9,8 @@ that exists on disk.
 """
 
 from pathlib import Path
+from urllib.parse import quote, urlparse, urlunparse
+from quoptuna.server.core.config import settings
 
 DB_DIR = Path("db")
 
@@ -42,4 +44,29 @@ def optuna_db_path(db_name: str) -> Path:
 
 
 def optuna_storage_url(db_name: str) -> str:
-    return f"sqlite:///{optuna_db_path(db_name)}"
+    url = ""
+    if settings.OPTUNA_DATABASE_URL:
+        url = settings.OPTUNA_DATABASE_URL
+    elif settings.DATABASE_URL.startswith(("postgresql://", "postgresql+")):
+        url = settings.DATABASE_URL
+    else:
+        return f"sqlite:///{optuna_db_path(db_name)}"
+    ensure_optuna_schema()
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+psycopg://", 1)
+    parsed = urlparse(url)
+    options = quote(f"-csearch_path={settings.OPTUNA_DB_SCHEMA}", safe="")
+    separator = "&" if parsed.query else ""
+    return urlunparse(parsed._replace(query=f"{parsed.query}{separator}options={options}"))
+
+
+def ensure_optuna_schema() -> None:
+    """Create the isolated PostgreSQL schema used by Optuna."""
+    url = settings.OPTUNA_DATABASE_URL or settings.DATABASE_URL
+    if not url.startswith(("postgresql://", "postgresql+")):
+        return
+    from sqlalchemy import create_engine, text  # noqa: PLC0415
+    engine = create_engine(url)
+    with engine.begin() as connection:
+        schema = settings.OPTUNA_DB_SCHEMA.replace('"', '""')
+        connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))  # noqa: S608

--- a/src/quoptuna/backend/utils/storage.py
+++ b/src/quoptuna/backend/utils/storage.py
@@ -66,6 +66,7 @@ def ensure_optuna_schema() -> None:
     if not url.startswith(("postgresql://", "postgresql+")):
         return
     from sqlalchemy import create_engine, text  # noqa: PLC0415
+
     if url.startswith("postgresql://"):
         url = url.replace("postgresql://", "postgresql+psycopg://", 1)
     engine = create_engine(url)

--- a/src/quoptuna/backend/utils/storage.py
+++ b/src/quoptuna/backend/utils/storage.py
@@ -51,7 +51,6 @@ def optuna_storage_url(db_name: str) -> str:
         url = settings.DATABASE_URL
     else:
         return f"sqlite:///{optuna_db_path(db_name)}"
-    ensure_optuna_schema()
     if url.startswith("postgresql://"):
         url = url.replace("postgresql://", "postgresql+psycopg://", 1)
     parsed = urlparse(url)
@@ -66,6 +65,8 @@ def ensure_optuna_schema() -> None:
     if not url.startswith(("postgresql://", "postgresql+")):
         return
     from sqlalchemy import create_engine, text  # noqa: PLC0415
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+psycopg://", 1)
     engine = create_engine(url)
     with engine.begin() as connection:
         schema = settings.OPTUNA_DB_SCHEMA.replace('"', '""')

--- a/src/quoptuna/cli.py
+++ b/src/quoptuna/cli.py
@@ -385,6 +385,22 @@ def optimize(  # noqa: PLR0913
     console.print_json(json.dumps(summary, default=str))
 
 
+@app.command("migrate-supabase")
+def migrate_supabase(
+    source_db: str = typer.Option("db/quoptuna_app.db", "--source-db"),
+    database_url: str = typer.Option(None, "--database-url"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+) -> None:
+    """Migrate legacy application metadata into SQLModel/PostgreSQL."""
+    import json  # noqa: PLC0415
+    from quoptuna.server.core.config import settings  # noqa: PLC0415
+    from quoptuna.server.services.migration import migrate_app_store  # noqa: PLC0415
+
+    target = database_url or settings.DATABASE_URL
+    result = migrate_app_store(source_db, target, dry_run=dry_run)
+    console.print_json(json.dumps(result))
+
+
 def main() -> None:
     from quoptuna.backend.utils.log_file import attach_file_logging  # noqa: PLC0415
 

--- a/src/quoptuna/cli.py
+++ b/src/quoptuna/cli.py
@@ -393,6 +393,7 @@ def migrate_supabase(
 ) -> None:
     """Migrate legacy application metadata into SQLModel/PostgreSQL."""
     import json  # noqa: PLC0415
+
     from quoptuna.server.core.config import settings  # noqa: PLC0415
     from quoptuna.server.services.migration import migrate_app_store  # noqa: PLC0415
 

--- a/src/quoptuna/cli.py
+++ b/src/quoptuna/cli.py
@@ -401,6 +401,58 @@ def migrate_supabase(
     console.print_json(json.dumps(result))
 
 
+@app.command("migrate-optuna")
+def migrate_optuna(
+    source_db: str = typer.Argument(..., help="Local Optuna SQLite database, e.g. db/results.db."),
+    study_name: str = typer.Option(None, "--study-name", help="Migrate only this study."),
+    target_url: str = typer.Option(None, "--target-url", help="Override OPTUNA_DATABASE_URL."),
+) -> None:
+    """Copy Optuna studies from a local SQLite database to PostgreSQL/Supabase."""
+    import optuna  # noqa: PLC0415
+
+    from quoptuna.backend.utils.storage import (  # noqa: PLC0415
+        ensure_optuna_schema,
+        optuna_storage_url,
+    )
+    from quoptuna.server.core.config import settings  # noqa: PLC0415
+
+    source_path = Path(source_db)
+    if not source_path.exists():
+        console.print(f"[red]Source database not found:[/red] {source_db}")
+        raise typer.Exit(1)
+    if source_path.suffix.lower() != ".db":
+        console.print("[red]Source must be a SQLite .db file.[/red]")
+        raise typer.Exit(2)
+    if not (target_url or settings.OPTUNA_DATABASE_URL):
+        console.print("[red]Set OPTUNA_DATABASE_URL or pass --target-url.[/red]")
+        raise typer.Exit(2)
+
+    if target_url:
+        settings.OPTUNA_DATABASE_URL = target_url
+    source = f"sqlite:///{source_path}"
+    target = optuna_storage_url(source_path.stem)
+    ensure_optuna_schema()
+
+    summaries = optuna.study.get_all_study_summaries(storage=source)
+    if study_name:
+        summaries = [summary for summary in summaries if summary.study_name == study_name]
+        if not summaries:
+            console.print(f"[red]Study not found:[/red] {study_name}")
+            raise typer.Exit(1)
+
+    migrated = 0
+    for summary in summaries:
+        console.print(f"Migrating [bold]{summary.study_name}[/bold] ({summary.n_trials} trials)")
+        optuna.copy_study(
+            from_study_name=summary.study_name,
+            from_storage=source,
+            to_storage=target,
+            to_study_name=summary.study_name,
+        )
+        migrated += 1
+    console.print(f"[green]Migrated {migrated} study/studies.[/green]")
+
+
 def main() -> None:
     from quoptuna.backend.utils.log_file import attach_file_logging  # noqa: PLC0415
 

--- a/src/quoptuna/server/api/v1/analysis.py
+++ b/src/quoptuna/server/api/v1/analysis.py
@@ -591,6 +591,20 @@ async def get_analysis_snapshot(snapshot_id: str):
     return snapshot
 
 
+@router.get("/snapshots/{snapshot_id}/artifacts/{filename}")
+async def get_analysis_artifact(snapshot_id: str, filename: str):
+    """Return a short-lived S3 URL for an analysis artifact."""
+    if "/" in filename or "\\" in filename or filename in (".", ".."):
+        raise HTTPException(status_code=400, detail="Invalid artifact filename")
+    url = analysis_store.artifact_url(snapshot_id, filename)
+    if url:
+        return {"snapshot_id": snapshot_id, "filename": filename, "url": url}
+    snapshot = analysis_store.get_snapshot(snapshot_id, hydrate=False)
+    if not snapshot:
+        raise HTTPException(status_code=404, detail="Analysis snapshot not found")
+    raise HTTPException(status_code=404, detail="Artifact is not stored in object storage")
+
+
 @router.get("/snapshots/{snapshot_id}/reports")
 async def list_snapshot_reports(snapshot_id: str):
     if not analysis_store.get_snapshot(snapshot_id, hydrate=False):

--- a/src/quoptuna/server/api/v1/data.py
+++ b/src/quoptuna/server/api/v1/data.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 
 from quoptuna.server.core.config import settings
 from quoptuna.server.services import dataset_registry
+from quoptuna.server.services.analysis_store import get_artifact_store
 
 router = APIRouter()
 
@@ -89,12 +90,20 @@ async def upload_dataset(file: UploadFile = File(...)):
 
         df = pd.read_csv(file_path)
 
+        object_key = None
+        artifact_store = get_artifact_store()
+        if artifact_store:
+            object_key = artifact_store.upload_file(
+                file_path, f"{settings.S3_PREFIX.strip('/')}/datasets/{file_id}.csv", "text/csv"
+            )
+
         dataset_registry.register(
             {
                 "id": file_id,
                 "name": filename,
                 "source": "upload",
                 "file_path": str(file_path),
+                "object_key": object_key,
                 "rows": len(df),
                 "columns": list(df.columns),
             }
@@ -107,6 +116,7 @@ async def upload_dataset(file: UploadFile = File(...)):
                 "filename": file.filename,
                 "id": file_id,
                 "file_path": str(file_path),
+                "object_key": object_key,
                 "rows": len(df),
                 "columns": list(df.columns),
             },

--- a/src/quoptuna/server/api/v1/optimize.py
+++ b/src/quoptuna/server/api/v1/optimize.py
@@ -12,6 +12,7 @@ from optuna.trial import TrialState
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from quoptuna.server.services import dataset_registry, run_store
+from quoptuna.server.core.config import settings
 from quoptuna.server.services.storage import optuna_storage_url
 from quoptuna.server.services.workflow_service import WorkflowExecutor
 
@@ -37,6 +38,8 @@ class OptimizationRequest(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     dataset_id: str
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
     dataset_source: str  # 'uci' or 'upload'
     selected_features: List[str]
     target_column: str
@@ -344,6 +347,9 @@ def get_job(job_id: str) -> Dict[str, Any]:
 async def start_optimization(request: OptimizationRequest, background_tasks: BackgroundTasks):
     """Start a new optimization study"""
     job_id = f"opt_{uuid.uuid4().hex[:8]}"
+    session_id = request.session_id or str(uuid.uuid4())
+    request.session_id = session_id
+    dataset_record = dataset_registry.get(request.dataset_id)
 
     optimization_jobs[job_id] = {
         "id": job_id,
@@ -357,6 +363,12 @@ async def start_optimization(request: OptimizationRequest, background_tasks: Bac
         "completed_at": None,
         "error": None,
         "request": request.dict(),  # Store request for later use
+        "session_id": session_id,
+        "user_id": request.user_id,
+        "source_file_id": request.dataset_id,
+        "source_file_path": (dataset_record or {}).get("file_path"),
+        "study_storage_key": request.database_name,
+        "artifact_storage": settings.ARTIFACT_STORAGE,
     }
     run_store.save_run(optimization_jobs[job_id])
 
@@ -426,6 +438,11 @@ async def get_optimization_detail(optimization_id: str):
         "error": job.get("error"),
         "request": request_data,
         "dataset": record,
+        "session_id": job.get("session_id"),
+        "user_id": job.get("user_id"),
+        "source_file_id": job.get("source_file_id") or request_data.get("dataset_id"),
+        "study_storage_key": job.get("study_storage_key") or request_data.get("database_name"),
+        "artifact_storage": job.get("artifact_storage") or settings.ARTIFACT_STORAGE,
     }
 
 

--- a/src/quoptuna/server/api/v1/optimize.py
+++ b/src/quoptuna/server/api/v1/optimize.py
@@ -11,8 +11,8 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException
 from optuna.trial import TrialState
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from quoptuna.server.services import dataset_registry, run_store
 from quoptuna.server.core.config import settings
+from quoptuna.server.services import dataset_registry, run_store
 from quoptuna.server.services.storage import optuna_storage_url
 from quoptuna.server.services.workflow_service import WorkflowExecutor
 

--- a/src/quoptuna/server/core/config.py
+++ b/src/quoptuna/server/core/config.py
@@ -31,7 +31,19 @@ class Settings(BaseSettings):
         return v
 
     # Database
-    DATABASE_URL: str = "sqlite:///./quoptuna.db"
+    DATABASE_URL: str = "sqlite:///./db/quoptuna_app.db"
+    # Optuna may use the same database, or a separate one, in deployments.
+    OPTUNA_DATABASE_URL: str = ""
+    OPTUNA_DB_SCHEMA: str = "optuna"
+    ARTIFACT_STORAGE: str = "local"
+    ARTIFACT_ROOT: str = "db/analysis"
+    S3_ENDPOINT_URL: str = ""
+    S3_BUCKET: str = ""
+    S3_REGION: str = ""
+    S3_ACCESS_KEY_ID: str = ""
+    S3_SECRET_ACCESS_KEY: str = ""
+    S3_PREFIX: str = "quoptuna"
+    S3_SIGNED_URL_TTL: int = 900
 
     # File Upload
     UPLOAD_DIR: str = "./uploads"

--- a/src/quoptuna/server/services/analysis_store.py
+++ b/src/quoptuna/server/services/analysis_store.py
@@ -1,4 +1,4 @@
-"""Durable analysis snapshots, binary artifacts, jobs, and generated reports."""
+"""Durable analysis snapshots, reports, and local/S3 artifacts."""
 
 from __future__ import annotations
 
@@ -11,58 +11,19 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from sqlmodel import select
+
+from quoptuna.server.core.config import settings
+from quoptuna.server.services.database import session_scope
+from quoptuna.server.services.models import (
+    AnalysisArtifact,
+    AnalysisJob,
+    AnalysisReport,
+    AnalysisSnapshot,
+)
 from quoptuna.server.services import run_store
-from quoptuna.server.services.storage import ensure_db_dir
 
-ARTIFACT_ROOT = Path("db/analysis")
-
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS analysis_snapshots (
-    id TEXT PRIMARY KEY,
-    optimization_id TEXT NOT NULL,
-    config_key TEXT NOT NULL,
-    config_json TEXT NOT NULL,
-    revision INTEGER NOT NULL DEFAULT 0,
-    payload_json TEXT,
-    artifact_dir TEXT,
-    created_at TEXT NOT NULL,
-    completed_at TEXT,
-    UNIQUE(optimization_id, config_key)
-);
-CREATE TABLE IF NOT EXISTS analysis_jobs (
-    id TEXT PRIMARY KEY,
-    snapshot_id TEXT NOT NULL,
-    status TEXT NOT NULL,
-    current_section TEXT,
-    error TEXT,
-    created_at TEXT NOT NULL,
-    completed_at TEXT
-);
-CREATE TABLE IF NOT EXISTS analysis_reports (
-    id TEXT PRIMARY KEY,
-    optimization_id TEXT NOT NULL,
-    snapshot_id TEXT NOT NULL,
-    snapshot_revision INTEGER NOT NULL,
-    status TEXT NOT NULL,
-    provider TEXT NOT NULL,
-    model_name TEXT NOT NULL,
-    dataset_description TEXT,
-    markdown TEXT,
-    error TEXT,
-    created_at TEXT NOT NULL,
-    completed_at TEXT
-);
-CREATE INDEX IF NOT EXISTS analysis_snapshots_run_idx
-    ON analysis_snapshots(optimization_id, completed_at DESC);
-CREATE INDEX IF NOT EXISTS analysis_reports_snapshot_idx
-    ON analysis_reports(snapshot_id, completed_at DESC);
-"""
-
-
-def _connect():
-    conn = run_store._connect()  # noqa: SLF001 - shares the app database intentionally
-    conn.executescript(_SCHEMA)
-    return conn
+ARTIFACT_ROOT = Path(settings.ARTIFACT_ROOT)
 
 
 def _now() -> str:
@@ -88,78 +49,69 @@ def create_job(optimization_id: str, config: dict[str, Any]) -> dict[str, Any]:
     config = normalize_config(config)
     key = _config_key(config)
     now = _now()
-    with _connect() as conn:
-        row = conn.execute(
-            "SELECT id FROM analysis_snapshots WHERE optimization_id = ? AND config_key = ?",
-            (optimization_id, key),
-        ).fetchone()
-        snapshot_id = row["id"] if row else str(uuid.uuid4())
-        if not row:
-            conn.execute(
-                "INSERT INTO analysis_snapshots "
-                "(id, optimization_id, config_key, config_json, created_at) VALUES (?, ?, ?, ?, ?)",
-                (snapshot_id, optimization_id, key, json.dumps(config), now),
+    with session_scope() as session:
+        snapshot = session.exec(
+            select(AnalysisSnapshot).where(
+                AnalysisSnapshot.optimization_id == optimization_id,
+                AnalysisSnapshot.config_key == key,
             )
-        active = conn.execute(
-            "SELECT id, status FROM analysis_jobs WHERE snapshot_id = ? "
-            "AND status IN ('pending', 'running') ORDER BY created_at DESC LIMIT 1",
-            (snapshot_id,),
-        ).fetchone()
+        ).first()
+        if snapshot is None:
+            snapshot = AnalysisSnapshot(
+                id=str(uuid.uuid4()), optimization_id=optimization_id,
+                config_key=key, config_json=json.dumps(config), created_at=now,
+            )
+            session.add(snapshot)
+            session.commit()
+            session.refresh(snapshot)
+        active = session.exec(
+            select(AnalysisJob).where(
+                AnalysisJob.snapshot_id == snapshot.id,
+                AnalysisJob.status.in_(["pending", "running"]),
+            ).order_by(AnalysisJob.created_at.desc())
+        ).first()
         if active:
-            return {
-                "id": active["id"],
-                "snapshot_id": snapshot_id,
-                "status": active["status"],
-                "created": False,
-            }
-        job_id = str(uuid.uuid4())
-        conn.execute(
-            "INSERT INTO analysis_jobs (id, snapshot_id, status, created_at) VALUES (?, ?, ?, ?)",
-            (job_id, snapshot_id, "pending", now),
-        )
-    return {"id": job_id, "snapshot_id": snapshot_id, "status": "pending", "created": True}
+            return {"id": active.id, "snapshot_id": snapshot.id, "status": active.status, "created": False}
+        job = AnalysisJob(id=str(uuid.uuid4()), snapshot_id=snapshot.id, status="pending", created_at=now)
+        session.add(job)
+        session.commit()
+        return {"id": job.id, "snapshot_id": snapshot.id, "status": job.status, "created": True}
 
 
 def create_revision_job(snapshot_id: str) -> dict[str, Any]:
-    job_id = str(uuid.uuid4())
-    with _connect() as conn:
-        row = conn.execute(
-            "SELECT id FROM analysis_snapshots WHERE id = ? AND revision > 0", (snapshot_id,)
-        ).fetchone()
-        if not row:
+    with session_scope() as session:
+        snapshot = session.get(AnalysisSnapshot, snapshot_id)
+        if not snapshot or snapshot.revision <= 0:
             raise KeyError(snapshot_id)
-        conn.execute(
-            "INSERT INTO analysis_jobs (id, snapshot_id, status, created_at) VALUES (?, ?, 'running', ?)",
-            (job_id, snapshot_id, _now()),
-        )
-    return {"id": job_id, "snapshot_id": snapshot_id, "status": "running"}
+        job = AnalysisJob(id=str(uuid.uuid4()), snapshot_id=snapshot_id, status="running", created_at=_now())
+        session.add(job)
+        session.commit()
+        return {"id": job.id, "snapshot_id": snapshot_id, "status": "running"}
 
 
 def update_job(job_id: str, **fields: Any) -> None:
     allowed = {"status", "current_section", "error", "completed_at"}
     if set(fields) - allowed:
         raise ValueError("Invalid analysis job field")
-    assignments = ", ".join(f"{key} = ?" for key in fields)
-    with _connect() as conn:
-        conn.execute(
-            f"UPDATE analysis_jobs SET {assignments} WHERE id = ?",  # noqa: S608
-            (*fields.values(), job_id),
-        )
+    with session_scope() as session:
+        job = session.get(AnalysisJob, job_id)
+        if job:
+            for key, value in fields.items():
+                setattr(job, key, value)
+            session.add(job)
+            session.commit()
 
 
 def get_job(job_id: str) -> dict[str, Any] | None:
-    with _connect() as conn:
-        row = conn.execute(
-            "SELECT j.*, s.optimization_id, s.revision, s.config_json "
-            "FROM analysis_jobs j JOIN analysis_snapshots s ON s.id = j.snapshot_id "
-            "WHERE j.id = ?",
-            (job_id,),
-        ).fetchone()
-    if not row:
-        return None
-    result = dict(row)
-    result["config"] = json.loads(result.pop("config_json"))
-    return result
+    with session_scope() as session:
+        job = session.get(AnalysisJob, job_id)
+        if not job:
+            return None
+        snapshot = session.get(AnalysisSnapshot, job.snapshot_id)
+        result = job.model_dump()
+        result.update({"optimization_id": snapshot.optimization_id, "revision": snapshot.revision,
+                       "config": json.loads(snapshot.config_json)})
+        return result
 
 
 def _extract_artifacts(value: Any, directory: Path, prefix: str = "payload") -> Any:
@@ -171,15 +123,58 @@ def _extract_artifacts(value: Any, directory: Path, prefix: str = "payload") -> 
         (directory / filename).write_bytes(base64.b64decode(encoded))
         return {"$artifact": filename, "mime_type": mime}
     if isinstance(value, dict):
-        return {
-            key: _extract_artifacts(item, directory, f"{prefix}.{key}")
-            for key, item in value.items()
-        }
+        return {key: _extract_artifacts(item, directory, f"{prefix}.{key}") for key, item in value.items()}
     if isinstance(value, list):
-        return [
-            _extract_artifacts(item, directory, f"{prefix}.{i}") for i, item in enumerate(value)
-        ]
+        return [_extract_artifacts(item, directory, f"{prefix}.{i}") for i, item in enumerate(value)]
     return value
+
+
+class S3ArtifactStore:
+    def __init__(self):
+        import boto3
+        self.client = boto3.client("s3", endpoint_url=settings.S3_ENDPOINT_URL or None,
+                                   region_name=settings.S3_REGION or None,
+                                   aws_access_key_id=settings.S3_ACCESS_KEY_ID or None,
+                                   aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY or None)
+        self.bucket = settings.S3_BUCKET
+
+    def publish_tree(self, payload: Any, directory: Path, prefix: str, run_id: str, snapshot_id: str, revision: int) -> Any:
+        def replace(value: Any) -> Any:
+            if isinstance(value, dict) and "$artifact" in value:
+                filename = value["$artifact"]
+                key = f"{settings.S3_PREFIX.strip('/')}/{prefix}/{filename}"
+                path = directory / filename
+                self.client.upload_file(str(path), self.bucket, key,
+                                        ExtraArgs={"ContentType": value.get("mime_type", "application/octet-stream")})
+                with session_scope() as session:
+                    session.add(AnalysisArtifact(id=str(uuid.uuid4()), optimization_id=run_id,
+                        snapshot_id=snapshot_id, revision=revision, filename=filename,
+                        object_key=key, storage_backend="s3", mime_type=value.get("mime_type"),
+                        size_bytes=path.stat().st_size, checksum=hashlib.sha256(path.read_bytes()).hexdigest()))
+                    session.commit()
+                return {**value, "$object_key": key}
+            if isinstance(value, dict): return {k: replace(v) for k, v in value.items()}
+            if isinstance(value, list): return [replace(v) for v in value]
+            return value
+        return replace(payload)
+
+    def get_url(self, key: str) -> str:
+        return self.client.generate_presigned_url("get_object", Params={"Bucket": self.bucket, "Key": key}, ExpiresIn=settings.S3_SIGNED_URL_TTL)
+
+    def upload_file(self, path: Path, key: str, mime_type: str = "application/octet-stream") -> str:
+        self.client.upload_file(str(path), self.bucket, key, ExtraArgs={"ContentType": mime_type})
+        return key
+
+
+def get_artifact_store() -> S3ArtifactStore | None:
+    if settings.ARTIFACT_STORAGE.lower() != "s3":
+        return None
+    if not settings.S3_BUCKET:
+        raise RuntimeError("S3_BUCKET is required when ARTIFACT_STORAGE=s3")
+    try:
+        return S3ArtifactStore()
+    except ImportError as exc:
+        raise RuntimeError("Install boto3 to use S3 artifact storage") from exc
 
 
 def complete_job(job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -187,144 +182,109 @@ def complete_job(job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
     if not job:
         raise KeyError(job_id)
     revision = int(job["revision"]) + 1
-    ensure_db_dir()
     final_dir = ARTIFACT_ROOT / job["optimization_id"] / job["snapshot_id"] / str(revision)
     temp_dir = final_dir.with_name(f".{revision}-{job_id}.tmp")
     temp_dir.mkdir(parents=True, exist_ok=False)
     try:
         stored_payload = _extract_artifacts(payload, temp_dir)
+        backend = get_artifact_store()
+        prefix = f"runs/{job['optimization_id']}/analysis/{job['snapshot_id']}/revisions/{revision}"
+        if backend:
+            stored_payload = backend.publish_tree(stored_payload, temp_dir, prefix, job["optimization_id"], job["snapshot_id"], revision)
         final_dir.parent.mkdir(parents=True, exist_ok=True)
         temp_dir.replace(final_dir)
-        now = _now()
-        with _connect() as conn:
-            conn.execute(
-                "UPDATE analysis_snapshots SET revision = ?, payload_json = ?, "
-                "artifact_dir = ?, completed_at = ? WHERE id = ?",
-                (revision, json.dumps(stored_payload), str(final_dir), now, job["snapshot_id"]),
-            )
-            conn.execute(
-                "UPDATE analysis_jobs SET status = 'completed', current_section = 'complete', "
-                "completed_at = ? WHERE id = ?",
-                (now, job_id),
-            )
-        for old_revision in final_dir.parent.iterdir():
-            if old_revision != final_dir and old_revision.is_dir():
-                shutil.rmtree(old_revision, ignore_errors=True)
+        with session_scope() as session:
+            snapshot = session.get(AnalysisSnapshot, job["snapshot_id"])
+            snapshot.revision = revision
+            snapshot.payload_json = json.dumps(stored_payload)
+            snapshot.artifact_dir = str(final_dir)
+            snapshot.storage_backend = "s3" if backend else "local"
+            snapshot.artifact_prefix = prefix if backend else None
+            snapshot.completed_at = _now()
+            analysis_job = session.get(AnalysisJob, job_id)
+            analysis_job.status = "completed"
+            analysis_job.current_section = "complete"
+            analysis_job.completed_at = _now()
+            session.add(snapshot)
+            session.add(analysis_job)
+            session.commit()
+        for old in final_dir.parent.iterdir():
+            if old != final_dir and old.is_dir(): shutil.rmtree(old, ignore_errors=True)
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
     return {"snapshot_id": job["snapshot_id"], "revision": revision}
 
 
-def _hydrate_artifacts(value: Any, directory: Path) -> Any:
+def _hydrate(value: Any, directory: Path) -> Any:
+    if isinstance(value, dict) and "$object_key" in value:
+        store = get_artifact_store()
+        return store.get_url(value["$object_key"]) if store else value
     if isinstance(value, dict) and "$artifact" in value:
         path = directory / value["$artifact"]
-        encoded = base64.b64encode(path.read_bytes()).decode()
-        return f"data:{value.get('mime_type', 'application/octet-stream')};base64,{encoded}"
-    if isinstance(value, dict):
-        return {key: _hydrate_artifacts(item, directory) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_hydrate_artifacts(item, directory) for item in value]
+        return "data:%s;base64,%s" % (value.get("mime_type", "application/octet-stream"), base64.b64encode(path.read_bytes()).decode())
+    if isinstance(value, dict): return {k: _hydrate(v, directory) for k, v in value.items()}
+    if isinstance(value, list): return [_hydrate(v, directory) for v in value]
     return value
 
 
 def get_snapshot(snapshot_id: str, hydrate: bool = True) -> dict[str, Any] | None:
-    with _connect() as conn:
-        row = conn.execute(
-            "SELECT * FROM analysis_snapshots WHERE id = ?", (snapshot_id,)
-        ).fetchone()
-    if not row:
-        return None
-    result = dict(row)
-    result["config"] = json.loads(result.pop("config_json"))
-    raw_payload = json.loads(result.pop("payload_json") or "null")
-    result["payload"] = (
-        _hydrate_artifacts(raw_payload, Path(result["artifact_dir"]))
-        if hydrate and raw_payload is not None and result.get("artifact_dir")
-        else raw_payload
-    )
-    return result
+    with session_scope() as session:
+        row = session.get(AnalysisSnapshot, snapshot_id)
+        if not row: return None
+        result = row.model_dump()
+        result["config"] = json.loads(result.pop("config_json"))
+        raw = json.loads(result.pop("payload_json") or "null")
+        result["payload"] = _hydrate(raw, Path(result["artifact_dir"])) if hydrate and raw is not None and result.get("artifact_dir") else raw
+        return result
 
 
 def list_snapshots(optimization_id: str) -> list[dict[str, Any]]:
-    with _connect() as conn:
-        rows = conn.execute(
-            "SELECT id, optimization_id, revision, config_json, created_at, completed_at "
-            "FROM analysis_snapshots WHERE optimization_id = ? "
-            "AND revision > 0 ORDER BY completed_at DESC",
-            (optimization_id,),
-        ).fetchall()
-    return [
-        {
-            "id": row["id"],
-            "optimization_id": row["optimization_id"],
-            "revision": row["revision"],
-            "config": json.loads(row["config_json"]),
-            "created_at": row["created_at"],
-            "completed_at": row["completed_at"],
-        }
-        for row in rows
-    ]
+    with session_scope() as session:
+        rows = session.exec(select(AnalysisSnapshot).where(AnalysisSnapshot.optimization_id == optimization_id, AnalysisSnapshot.revision > 0).order_by(AnalysisSnapshot.completed_at.desc())).all()
+        return [{"id": r.id, "optimization_id": r.optimization_id, "revision": r.revision, "config": json.loads(r.config_json), "created_at": r.created_at, "completed_at": r.completed_at} for r in rows]
 
 
-def create_report(
-    snapshot: dict[str, Any], provider: str, model_name: str, description: str | None
-) -> str:
-    report_id = str(uuid.uuid4())
-    with _connect() as conn:
-        conn.execute(
-            "INSERT INTO analysis_reports (id, optimization_id, snapshot_id, snapshot_revision, "
-            "status, provider, model_name, dataset_description, created_at) "
-            "VALUES (?, ?, ?, ?, 'running', ?, ?, ?, ?)",
-            (
-                report_id,
-                snapshot["optimization_id"],
-                snapshot["id"],
-                snapshot["revision"],
-                provider,
-                model_name,
-                description,
-                _now(),
-            ),
-        )
-    return report_id
+def create_report(snapshot: dict[str, Any], provider: str, model_name: str, description: str | None) -> str:
+    report = AnalysisReport(id=str(uuid.uuid4()), optimization_id=snapshot["optimization_id"], snapshot_id=snapshot["id"], snapshot_revision=snapshot["revision"], status="running", provider=provider, model_name=model_name, dataset_description=description, created_at=_now())
+    with session_scope() as session:
+        session.add(report); session.commit()
+    return report.id
 
 
 def complete_report(report_id: str, markdown: str) -> None:
-    with _connect() as conn:
-        conn.execute(
-            "UPDATE analysis_reports SET status = 'completed', markdown = ?, completed_at = ? WHERE id = ?",
-            (markdown, _now(), report_id),
-        )
+    with session_scope() as session:
+        row = session.get(AnalysisReport, report_id)
+        if row: row.status, row.markdown, row.completed_at = "completed", markdown, _now(); session.add(row); session.commit()
 
 
 def fail_report(report_id: str, error: str) -> None:
-    with _connect() as conn:
-        conn.execute(
-            "UPDATE analysis_reports SET status = 'failed', error = ?, completed_at = ? WHERE id = ?",
-            (error, _now(), report_id),
-        )
+    with session_scope() as session:
+        row = session.get(AnalysisReport, report_id)
+        if row: row.status, row.error, row.completed_at = "failed", error, _now(); session.add(row); session.commit()
 
 
 def list_reports(snapshot_id: str) -> list[dict[str, Any]]:
-    with _connect() as conn:
-        rows = conn.execute(
-            "SELECT * FROM analysis_reports WHERE snapshot_id = ? ORDER BY created_at DESC",
-            (snapshot_id,),
-        ).fetchall()
-    return [dict(row) for row in rows]
+    with session_scope() as session:
+        return [r.model_dump() for r in session.exec(select(AnalysisReport).where(AnalysisReport.snapshot_id == snapshot_id).order_by(AnalysisReport.created_at.desc())).all()]
+
+
+def artifact_url(snapshot_id: str, filename: str) -> str | None:
+    with session_scope() as session:
+        row = session.exec(select(AnalysisArtifact).where(AnalysisArtifact.snapshot_id == snapshot_id, AnalysisArtifact.filename == filename)).first()
+    if not row or not row.object_key: return None
+    store = get_artifact_store()
+    return store.get_url(row.object_key) if store else None
 
 
 def delete_for_run(optimization_id: str) -> None:
-    with _connect() as conn:
-        snapshot_ids = [
-            row["id"]
-            for row in conn.execute(
-                "SELECT id FROM analysis_snapshots WHERE optimization_id = ?", (optimization_id,)
-            ).fetchall()
-        ]
+    with session_scope() as session:
+        snapshots = session.exec(select(AnalysisSnapshot).where(AnalysisSnapshot.optimization_id == optimization_id)).all()
+        snapshot_ids = [s.id for s in snapshots]
         for snapshot_id in snapshot_ids:
-            conn.execute("DELETE FROM analysis_jobs WHERE snapshot_id = ?", (snapshot_id,))
-            conn.execute("DELETE FROM analysis_reports WHERE snapshot_id = ?", (snapshot_id,))
-        conn.execute("DELETE FROM analysis_snapshots WHERE optimization_id = ?", (optimization_id,))
+            for row in session.exec(select(AnalysisJob).where(AnalysisJob.snapshot_id == snapshot_id)).all(): session.delete(row)
+            for row in session.exec(select(AnalysisReport).where(AnalysisReport.snapshot_id == snapshot_id)).all(): session.delete(row)
+            for row in session.exec(select(AnalysisArtifact).where(AnalysisArtifact.snapshot_id == snapshot_id)).all(): session.delete(row)
+            session.delete(session.get(AnalysisSnapshot, snapshot_id))
+        session.commit()
     shutil.rmtree(ARTIFACT_ROOT / optimization_id, ignore_errors=True)

--- a/src/quoptuna/server/services/analysis_store.py
+++ b/src/quoptuna/server/services/analysis_store.py
@@ -14,6 +14,7 @@ from typing import Any
 from sqlmodel import select
 
 from quoptuna.server.core.config import settings
+from quoptuna.server.services import run_store
 from quoptuna.server.services.database import session_scope
 from quoptuna.server.services.models import (
     AnalysisArtifact,
@@ -21,7 +22,6 @@ from quoptuna.server.services.models import (
     AnalysisReport,
     AnalysisSnapshot,
 )
-from quoptuna.server.services import run_store
 
 ARTIFACT_ROOT = Path(settings.ARTIFACT_ROOT)
 
@@ -58,21 +58,33 @@ def create_job(optimization_id: str, config: dict[str, Any]) -> dict[str, Any]:
         ).first()
         if snapshot is None:
             snapshot = AnalysisSnapshot(
-                id=str(uuid.uuid4()), optimization_id=optimization_id,
-                config_key=key, config_json=json.dumps(config), created_at=now,
+                id=str(uuid.uuid4()),
+                optimization_id=optimization_id,
+                config_key=key,
+                config_json=json.dumps(config),
+                created_at=now,
             )
             session.add(snapshot)
             session.commit()
             session.refresh(snapshot)
         active = session.exec(
-            select(AnalysisJob).where(
+            select(AnalysisJob)
+            .where(
                 AnalysisJob.snapshot_id == snapshot.id,
                 AnalysisJob.status.in_(["pending", "running"]),
-            ).order_by(AnalysisJob.created_at.desc())
+            )
+            .order_by(AnalysisJob.created_at.desc())
         ).first()
         if active:
-            return {"id": active.id, "snapshot_id": snapshot.id, "status": active.status, "created": False}
-        job = AnalysisJob(id=str(uuid.uuid4()), snapshot_id=snapshot.id, status="pending", created_at=now)
+            return {
+                "id": active.id,
+                "snapshot_id": snapshot.id,
+                "status": active.status,
+                "created": False,
+            }
+        job = AnalysisJob(
+            id=str(uuid.uuid4()), snapshot_id=snapshot.id, status="pending", created_at=now
+        )
         session.add(job)
         session.commit()
         return {"id": job.id, "snapshot_id": snapshot.id, "status": job.status, "created": True}
@@ -83,7 +95,9 @@ def create_revision_job(snapshot_id: str) -> dict[str, Any]:
         snapshot = session.get(AnalysisSnapshot, snapshot_id)
         if not snapshot or snapshot.revision <= 0:
             raise KeyError(snapshot_id)
-        job = AnalysisJob(id=str(uuid.uuid4()), snapshot_id=snapshot_id, status="running", created_at=_now())
+        job = AnalysisJob(
+            id=str(uuid.uuid4()), snapshot_id=snapshot_id, status="running", created_at=_now()
+        )
         session.add(job)
         session.commit()
         return {"id": job.id, "snapshot_id": snapshot_id, "status": "running"}
@@ -109,8 +123,13 @@ def get_job(job_id: str) -> dict[str, Any] | None:
             return None
         snapshot = session.get(AnalysisSnapshot, job.snapshot_id)
         result = job.model_dump()
-        result.update({"optimization_id": snapshot.optimization_id, "revision": snapshot.revision,
-                       "config": json.loads(snapshot.config_json)})
+        result.update(
+            {
+                "optimization_id": snapshot.optimization_id,
+                "revision": snapshot.revision,
+                "config": json.loads(snapshot.config_json),
+            }
+        )
         return result
 
 
@@ -123,43 +142,81 @@ def _extract_artifacts(value: Any, directory: Path, prefix: str = "payload") -> 
         (directory / filename).write_bytes(base64.b64decode(encoded))
         return {"$artifact": filename, "mime_type": mime}
     if isinstance(value, dict):
-        return {key: _extract_artifacts(item, directory, f"{prefix}.{key}") for key, item in value.items()}
+        return {
+            key: _extract_artifacts(item, directory, f"{prefix}.{key}")
+            for key, item in value.items()
+        }
     if isinstance(value, list):
-        return [_extract_artifacts(item, directory, f"{prefix}.{i}") for i, item in enumerate(value)]
+        return [
+            _extract_artifacts(item, directory, f"{prefix}.{i}") for i, item in enumerate(value)
+        ]
     return value
 
 
 class S3ArtifactStore:
     def __init__(self):
         import boto3
-        self.client = boto3.client("s3", endpoint_url=settings.S3_ENDPOINT_URL or None,
-                                   region_name=settings.S3_REGION or None,
-                                   aws_access_key_id=settings.S3_ACCESS_KEY_ID or None,
-                                   aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY or None)
+
+        self.client = boto3.client(
+            "s3",
+            endpoint_url=settings.S3_ENDPOINT_URL or None,
+            region_name=settings.S3_REGION or None,
+            aws_access_key_id=settings.S3_ACCESS_KEY_ID or None,
+            aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY or None,
+        )
         self.bucket = settings.S3_BUCKET
 
-    def publish_tree(self, payload: Any, directory: Path, prefix: str, run_id: str, snapshot_id: str, revision: int) -> Any:
+    def publish_tree(
+        self,
+        payload: Any,
+        directory: Path,
+        prefix: str,
+        run_id: str,
+        snapshot_id: str,
+        revision: int,
+    ) -> Any:
         def replace(value: Any) -> Any:
             if isinstance(value, dict) and "$artifact" in value:
                 filename = value["$artifact"]
                 key = f"{settings.S3_PREFIX.strip('/')}/{prefix}/{filename}"
                 path = directory / filename
-                self.client.upload_file(str(path), self.bucket, key,
-                                        ExtraArgs={"ContentType": value.get("mime_type", "application/octet-stream")})
+                self.client.upload_file(
+                    str(path),
+                    self.bucket,
+                    key,
+                    ExtraArgs={"ContentType": value.get("mime_type", "application/octet-stream")},
+                )
                 with session_scope() as session:
-                    session.add(AnalysisArtifact(id=str(uuid.uuid4()), optimization_id=run_id,
-                        snapshot_id=snapshot_id, revision=revision, filename=filename,
-                        object_key=key, storage_backend="s3", mime_type=value.get("mime_type"),
-                        size_bytes=path.stat().st_size, checksum=hashlib.sha256(path.read_bytes()).hexdigest()))
+                    session.add(
+                        AnalysisArtifact(
+                            id=str(uuid.uuid4()),
+                            optimization_id=run_id,
+                            snapshot_id=snapshot_id,
+                            revision=revision,
+                            filename=filename,
+                            object_key=key,
+                            storage_backend="s3",
+                            mime_type=value.get("mime_type"),
+                            size_bytes=path.stat().st_size,
+                            checksum=hashlib.sha256(path.read_bytes()).hexdigest(),
+                        )
+                    )
                     session.commit()
                 return {**value, "$object_key": key}
-            if isinstance(value, dict): return {k: replace(v) for k, v in value.items()}
-            if isinstance(value, list): return [replace(v) for v in value]
+            if isinstance(value, dict):
+                return {k: replace(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [replace(v) for v in value]
             return value
+
         return replace(payload)
 
     def get_url(self, key: str) -> str:
-        return self.client.generate_presigned_url("get_object", Params={"Bucket": self.bucket, "Key": key}, ExpiresIn=settings.S3_SIGNED_URL_TTL)
+        return self.client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=settings.S3_SIGNED_URL_TTL,
+        )
 
     def upload_file(self, path: Path, key: str, mime_type: str = "application/octet-stream") -> str:
         self.client.upload_file(str(path), self.bucket, key, ExtraArgs={"ContentType": mime_type})
@@ -190,7 +247,14 @@ def complete_job(job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         backend = get_artifact_store()
         prefix = f"runs/{job['optimization_id']}/analysis/{job['snapshot_id']}/revisions/{revision}"
         if backend:
-            stored_payload = backend.publish_tree(stored_payload, temp_dir, prefix, job["optimization_id"], job["snapshot_id"], revision)
+            stored_payload = backend.publish_tree(
+                stored_payload,
+                temp_dir,
+                prefix,
+                job["optimization_id"],
+                job["snapshot_id"],
+                revision,
+            )
         final_dir.parent.mkdir(parents=True, exist_ok=True)
         temp_dir.replace(final_dir)
         with session_scope() as session:
@@ -209,7 +273,8 @@ def complete_job(job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
             session.add(analysis_job)
             session.commit()
         for old in final_dir.parent.iterdir():
-            if old != final_dir and old.is_dir(): shutil.rmtree(old, ignore_errors=True)
+            if old != final_dir and old.is_dir():
+                shutil.rmtree(old, ignore_errors=True)
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
@@ -222,69 +287,137 @@ def _hydrate(value: Any, directory: Path) -> Any:
         return store.get_url(value["$object_key"]) if store else value
     if isinstance(value, dict) and "$artifact" in value:
         path = directory / value["$artifact"]
-        return "data:%s;base64,%s" % (value.get("mime_type", "application/octet-stream"), base64.b64encode(path.read_bytes()).decode())
-    if isinstance(value, dict): return {k: _hydrate(v, directory) for k, v in value.items()}
-    if isinstance(value, list): return [_hydrate(v, directory) for v in value]
+        return "data:%s;base64,%s" % (
+            value.get("mime_type", "application/octet-stream"),
+            base64.b64encode(path.read_bytes()).decode(),
+        )
+    if isinstance(value, dict):
+        return {k: _hydrate(v, directory) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_hydrate(v, directory) for v in value]
     return value
 
 
 def get_snapshot(snapshot_id: str, hydrate: bool = True) -> dict[str, Any] | None:
     with session_scope() as session:
         row = session.get(AnalysisSnapshot, snapshot_id)
-        if not row: return None
+        if not row:
+            return None
         result = row.model_dump()
         result["config"] = json.loads(result.pop("config_json"))
         raw = json.loads(result.pop("payload_json") or "null")
-        result["payload"] = _hydrate(raw, Path(result["artifact_dir"])) if hydrate and raw is not None and result.get("artifact_dir") else raw
+        result["payload"] = (
+            _hydrate(raw, Path(result["artifact_dir"]))
+            if hydrate and raw is not None and result.get("artifact_dir")
+            else raw
+        )
         return result
 
 
 def list_snapshots(optimization_id: str) -> list[dict[str, Any]]:
     with session_scope() as session:
-        rows = session.exec(select(AnalysisSnapshot).where(AnalysisSnapshot.optimization_id == optimization_id, AnalysisSnapshot.revision > 0).order_by(AnalysisSnapshot.completed_at.desc())).all()
-        return [{"id": r.id, "optimization_id": r.optimization_id, "revision": r.revision, "config": json.loads(r.config_json), "created_at": r.created_at, "completed_at": r.completed_at} for r in rows]
+        rows = session.exec(
+            select(AnalysisSnapshot)
+            .where(
+                AnalysisSnapshot.optimization_id == optimization_id, AnalysisSnapshot.revision > 0
+            )
+            .order_by(AnalysisSnapshot.completed_at.desc())
+        ).all()
+        return [
+            {
+                "id": r.id,
+                "optimization_id": r.optimization_id,
+                "revision": r.revision,
+                "config": json.loads(r.config_json),
+                "created_at": r.created_at,
+                "completed_at": r.completed_at,
+            }
+            for r in rows
+        ]
 
 
-def create_report(snapshot: dict[str, Any], provider: str, model_name: str, description: str | None) -> str:
-    report = AnalysisReport(id=str(uuid.uuid4()), optimization_id=snapshot["optimization_id"], snapshot_id=snapshot["id"], snapshot_revision=snapshot["revision"], status="running", provider=provider, model_name=model_name, dataset_description=description, created_at=_now())
+def create_report(
+    snapshot: dict[str, Any], provider: str, model_name: str, description: str | None
+) -> str:
+    report = AnalysisReport(
+        id=str(uuid.uuid4()),
+        optimization_id=snapshot["optimization_id"],
+        snapshot_id=snapshot["id"],
+        snapshot_revision=snapshot["revision"],
+        status="running",
+        provider=provider,
+        model_name=model_name,
+        dataset_description=description,
+        created_at=_now(),
+    )
     with session_scope() as session:
-        session.add(report); session.commit()
+        session.add(report)
+        session.commit()
     return report.id
 
 
 def complete_report(report_id: str, markdown: str) -> None:
     with session_scope() as session:
         row = session.get(AnalysisReport, report_id)
-        if row: row.status, row.markdown, row.completed_at = "completed", markdown, _now(); session.add(row); session.commit()
+        if row:
+            row.status, row.markdown, row.completed_at = "completed", markdown, _now()
+            session.add(row)
+            session.commit()
 
 
 def fail_report(report_id: str, error: str) -> None:
     with session_scope() as session:
         row = session.get(AnalysisReport, report_id)
-        if row: row.status, row.error, row.completed_at = "failed", error, _now(); session.add(row); session.commit()
+        if row:
+            row.status, row.error, row.completed_at = "failed", error, _now()
+            session.add(row)
+            session.commit()
 
 
 def list_reports(snapshot_id: str) -> list[dict[str, Any]]:
     with session_scope() as session:
-        return [r.model_dump() for r in session.exec(select(AnalysisReport).where(AnalysisReport.snapshot_id == snapshot_id).order_by(AnalysisReport.created_at.desc())).all()]
+        return [
+            r.model_dump()
+            for r in session.exec(
+                select(AnalysisReport)
+                .where(AnalysisReport.snapshot_id == snapshot_id)
+                .order_by(AnalysisReport.created_at.desc())
+            ).all()
+        ]
 
 
 def artifact_url(snapshot_id: str, filename: str) -> str | None:
     with session_scope() as session:
-        row = session.exec(select(AnalysisArtifact).where(AnalysisArtifact.snapshot_id == snapshot_id, AnalysisArtifact.filename == filename)).first()
-    if not row or not row.object_key: return None
+        row = session.exec(
+            select(AnalysisArtifact).where(
+                AnalysisArtifact.snapshot_id == snapshot_id, AnalysisArtifact.filename == filename
+            )
+        ).first()
+    if not row or not row.object_key:
+        return None
     store = get_artifact_store()
     return store.get_url(row.object_key) if store else None
 
 
 def delete_for_run(optimization_id: str) -> None:
     with session_scope() as session:
-        snapshots = session.exec(select(AnalysisSnapshot).where(AnalysisSnapshot.optimization_id == optimization_id)).all()
+        snapshots = session.exec(
+            select(AnalysisSnapshot).where(AnalysisSnapshot.optimization_id == optimization_id)
+        ).all()
         snapshot_ids = [s.id for s in snapshots]
         for snapshot_id in snapshot_ids:
-            for row in session.exec(select(AnalysisJob).where(AnalysisJob.snapshot_id == snapshot_id)).all(): session.delete(row)
-            for row in session.exec(select(AnalysisReport).where(AnalysisReport.snapshot_id == snapshot_id)).all(): session.delete(row)
-            for row in session.exec(select(AnalysisArtifact).where(AnalysisArtifact.snapshot_id == snapshot_id)).all(): session.delete(row)
+            for row in session.exec(
+                select(AnalysisJob).where(AnalysisJob.snapshot_id == snapshot_id)
+            ).all():
+                session.delete(row)
+            for row in session.exec(
+                select(AnalysisReport).where(AnalysisReport.snapshot_id == snapshot_id)
+            ).all():
+                session.delete(row)
+            for row in session.exec(
+                select(AnalysisArtifact).where(AnalysisArtifact.snapshot_id == snapshot_id)
+            ).all():
+                session.delete(row)
             session.delete(session.get(AnalysisSnapshot, snapshot_id))
         session.commit()
     shutil.rmtree(ARTIFACT_ROOT / optimization_id, ignore_errors=True)

--- a/src/quoptuna/server/services/analysis_store.py
+++ b/src/quoptuna/server/services/analysis_store.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlmodel import select
 
 from quoptuna.server.core.config import settings
-from quoptuna.server.services import run_store
 from quoptuna.server.services.database import session_scope
 from quoptuna.server.services.models import (
     AnalysisArtifact,
@@ -287,10 +286,7 @@ def _hydrate(value: Any, directory: Path) -> Any:
         return store.get_url(value["$object_key"]) if store else value
     if isinstance(value, dict) and "$artifact" in value:
         path = directory / value["$artifact"]
-        return "data:%s;base64,%s" % (
-            value.get("mime_type", "application/octet-stream"),
-            base64.b64encode(path.read_bytes()).decode(),
-        )
+        return f"data:{value.get('mime_type', 'application/octet-stream')};base64,{base64.b64encode(path.read_bytes()).decode()}"
     if isinstance(value, dict):
         return {k: _hydrate(v, directory) for k, v in value.items()}
     if isinstance(value, list):

--- a/src/quoptuna/server/services/analysis_store.py
+++ b/src/quoptuna/server/services/analysis_store.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from sqlmodel import select
+from sqlmodel import col, select
 
 from quoptuna.server.core.config import settings
 from quoptuna.server.services.database import session_scope
@@ -70,9 +70,9 @@ def create_job(optimization_id: str, config: dict[str, Any]) -> dict[str, Any]:
             select(AnalysisJob)
             .where(
                 AnalysisJob.snapshot_id == snapshot.id,
-                AnalysisJob.status.in_(["pending", "running"]),
+                col(AnalysisJob.status).in_(["pending", "running"]),
             )
-            .order_by(AnalysisJob.created_at.desc())
+            .order_by(col(AnalysisJob.created_at).desc())
         ).first()
         if active:
             return {
@@ -121,6 +121,8 @@ def get_job(job_id: str) -> dict[str, Any] | None:
         if not job:
             return None
         snapshot = session.get(AnalysisSnapshot, job.snapshot_id)
+        if snapshot is None:
+            return None
         result = job.model_dump()
         result.update(
             {
@@ -258,6 +260,8 @@ def complete_job(job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         temp_dir.replace(final_dir)
         with session_scope() as session:
             snapshot = session.get(AnalysisSnapshot, job["snapshot_id"])
+            if snapshot is None:
+                raise KeyError(job["snapshot_id"])
             snapshot.revision = revision
             snapshot.payload_json = json.dumps(stored_payload)
             snapshot.artifact_dir = str(final_dir)
@@ -265,6 +269,8 @@ def complete_job(job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
             snapshot.artifact_prefix = prefix if backend else None
             snapshot.completed_at = _now()
             analysis_job = session.get(AnalysisJob, job_id)
+            if analysis_job is None:
+                raise KeyError(job_id)
             analysis_job.status = "completed"
             analysis_job.current_section = "complete"
             analysis_job.completed_at = _now()
@@ -317,7 +323,7 @@ def list_snapshots(optimization_id: str) -> list[dict[str, Any]]:
             .where(
                 AnalysisSnapshot.optimization_id == optimization_id, AnalysisSnapshot.revision > 0
             )
-            .order_by(AnalysisSnapshot.completed_at.desc())
+            .order_by(col(AnalysisSnapshot.completed_at).desc())
         ).all()
         return [
             {
@@ -377,7 +383,7 @@ def list_reports(snapshot_id: str) -> list[dict[str, Any]]:
             for r in session.exec(
                 select(AnalysisReport)
                 .where(AnalysisReport.snapshot_id == snapshot_id)
-                .order_by(AnalysisReport.created_at.desc())
+                .order_by(col(AnalysisReport.created_at).desc())
             ).all()
         ]
 
@@ -402,18 +408,20 @@ def delete_for_run(optimization_id: str) -> None:
         ).all()
         snapshot_ids = [s.id for s in snapshots]
         for snapshot_id in snapshot_ids:
-            for row in session.exec(
+            for job_row in session.exec(
                 select(AnalysisJob).where(AnalysisJob.snapshot_id == snapshot_id)
             ).all():
-                session.delete(row)
-            for row in session.exec(
+                session.delete(job_row)
+            for report_row in session.exec(
                 select(AnalysisReport).where(AnalysisReport.snapshot_id == snapshot_id)
             ).all():
-                session.delete(row)
-            for row in session.exec(
+                session.delete(report_row)
+            for artifact_row in session.exec(
                 select(AnalysisArtifact).where(AnalysisArtifact.snapshot_id == snapshot_id)
             ).all():
-                session.delete(row)
-            session.delete(session.get(AnalysisSnapshot, snapshot_id))
+                session.delete(artifact_row)
+            snapshot_row = session.get(AnalysisSnapshot, snapshot_id)
+            if snapshot_row is not None:
+                session.delete(snapshot_row)
         session.commit()
     shutil.rmtree(ARTIFACT_ROOT / optimization_id, ignore_errors=True)

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -13,13 +13,18 @@ from quoptuna.server.core.config import settings
 def _database_url() -> str:
     # Keep the historical local location unless an explicit URL is configured.
     try:
-        from quoptuna.server.services import run_store  # noqa: PLC0415
+        from quoptuna.server.services import run_store
+
         if run_store.APP_DB_PATH != "db/quoptuna_app.db":
             return f"sqlite:///{run_store.APP_DB_PATH}"
     except ImportError:
         pass
     url = settings.DATABASE_URL or "sqlite:///./db/quoptuna_app.db"
-    return url.replace("postgresql://", "postgresql+psycopg://", 1) if url.startswith("postgresql://") else url
+    return (
+        url.replace("postgresql://", "postgresql+psycopg://", 1)
+        if url.startswith("postgresql://")
+        else url
+    )
 
 
 def _engine_kwargs(url: str) -> dict:
@@ -41,7 +46,7 @@ def get_engine():
 
 def init_db() -> None:
     """Create application tables; production schema changes use migrations."""
-    from quoptuna.server.services.models import (  # noqa: F401, PLC0415
+    from quoptuna.server.services.models import (
         AnalysisArtifact,
         AnalysisJob,
         AnalysisReport,

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -1,0 +1,60 @@
+"""SQLModel database engine and schema management."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from quoptuna.server.core.config import settings
+
+
+def _database_url() -> str:
+    # Keep the historical local location unless an explicit URL is configured.
+    try:
+        from quoptuna.server.services import run_store  # noqa: PLC0415
+        if run_store.APP_DB_PATH != "db/quoptuna_app.db":
+            return f"sqlite:///{run_store.APP_DB_PATH}"
+    except ImportError:
+        pass
+    url = settings.DATABASE_URL or "sqlite:///./db/quoptuna_app.db"
+    return url.replace("postgresql://", "postgresql+psycopg://", 1) if url.startswith("postgresql://") else url
+
+
+def _engine_kwargs(url: str) -> dict:
+    if url.startswith("sqlite"):
+        return {"connect_args": {"check_same_thread": False}}
+    return {"pool_pre_ping": True, "pool_recycle": 1800}
+
+
+engine = None
+
+
+def get_engine():
+    global engine
+    url = _database_url()
+    if engine is None or str(engine.url) != url:
+        engine = create_engine(url, **_engine_kwargs(url))
+    return engine
+
+
+def init_db() -> None:
+    """Create application tables; production schema changes use migrations."""
+    from quoptuna.server.services.models import (  # noqa: F401, PLC0415
+        AnalysisArtifact,
+        AnalysisJob,
+        AnalysisReport,
+        AnalysisSnapshot,
+        Dataset,
+        Run,
+    )
+
+    SQLModel.metadata.create_all(get_engine())
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    init_db()
+    with Session(get_engine(), expire_on_commit=False) as session:
+        yield session

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -60,7 +60,7 @@ def get_engine(url: str | None = None):
 def init_db() -> None:
     """Create application tables; production schema changes use migrations."""
     SQLModel.metadata.create_all(
-        get_engine(), tables=[model.__table__ for model in APPLICATION_MODELS]
+        get_engine(), tables=[model.__table__ for model in APPLICATION_MODELS]  # type: ignore[attr-defined, union-attr]
     )
 
 

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -9,6 +9,23 @@ from typing import Iterator
 from sqlmodel import Session, SQLModel, create_engine
 
 from quoptuna.server.core.config import settings
+from quoptuna.server.services.models import (
+    AnalysisArtifact,
+    AnalysisJob,
+    AnalysisReport,
+    AnalysisSnapshot,
+    Dataset,
+    Run,
+)
+
+APPLICATION_MODELS = (
+    Run,
+    Dataset,
+    AnalysisSnapshot,
+    AnalysisJob,
+    AnalysisReport,
+    AnalysisArtifact,
+)
 
 
 def _database_url() -> str:
@@ -42,9 +59,9 @@ def get_engine(url: str | None = None):
 
 def init_db() -> None:
     """Create application tables; production schema changes use migrations."""
-    from quoptuna.server.services import models as _models  # noqa: F401
-
-    SQLModel.metadata.create_all(get_engine())
+    SQLModel.metadata.create_all(
+        get_engine(), tables=[model.__table__ for model in APPLICATION_MODELS]
+    )
 
 
 @contextmanager

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -60,7 +60,8 @@ def get_engine(url: str | None = None):
 def init_db() -> None:
     """Create application tables; production schema changes use migrations."""
     SQLModel.metadata.create_all(
-        get_engine(), tables=[model.__table__ for model in APPLICATION_MODELS]  # type: ignore[attr-defined, union-attr]
+        get_engine(),
+        tables=[model.__table__ for model in APPLICATION_MODELS],  # type: ignore[attr-defined, union-attr]
     )
 
 

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -42,7 +42,7 @@ def get_engine(url: str | None = None):
 
 def init_db() -> None:
     """Create application tables; production schema changes use migrations."""
-    from quoptuna.server.services import models as _models  # noqa: F401
+    from quoptuna.server.services import models as _models
 
     SQLModel.metadata.create_all(get_engine())
 

--- a/src/quoptuna/server/services/database.py
+++ b/src/quoptuna/server/services/database.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from functools import lru_cache
 from typing import Iterator
 
 from sqlmodel import Session, SQLModel, create_engine
@@ -33,27 +34,15 @@ def _engine_kwargs(url: str) -> dict:
     return {"pool_pre_ping": True, "pool_recycle": 1800}
 
 
-engine = None
-
-
-def get_engine():
-    global engine
-    url = _database_url()
-    if engine is None or str(engine.url) != url:
-        engine = create_engine(url, **_engine_kwargs(url))
-    return engine
+@lru_cache(maxsize=8)
+def get_engine(url: str | None = None):
+    url = url or _database_url()
+    return create_engine(url, **_engine_kwargs(url))
 
 
 def init_db() -> None:
     """Create application tables; production schema changes use migrations."""
-    from quoptuna.server.services.models import (
-        AnalysisArtifact,
-        AnalysisJob,
-        AnalysisReport,
-        AnalysisSnapshot,
-        Dataset,
-        Run,
-    )
+    from quoptuna.server.services import models as _models  # noqa: F401
 
     SQLModel.metadata.create_all(get_engine())
 

--- a/src/quoptuna/server/services/dataset_registry.py
+++ b/src/quoptuna/server/services/dataset_registry.py
@@ -18,6 +18,7 @@ class DatasetRecord(TypedDict, total=False):
     name: str
     source: str  # 'upload' | 'uci'
     file_path: str
+    object_key: Optional[str]
     rows: int
     columns: List[str]
 

--- a/src/quoptuna/server/services/migration.py
+++ b/src/quoptuna/server/services/migration.py
@@ -9,62 +9,152 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from sqlmodel import Session, SQLModel
 
-from quoptuna.server.services.models import AnalysisJob, AnalysisReport, AnalysisSnapshot, Dataset, Run
+from quoptuna.server.services.models import (
+    AnalysisJob,
+    AnalysisReport,
+    AnalysisSnapshot,
+    Dataset,
+    Run,
+)
 
 
-def migrate_app_store(source: str | Path, target_url: str, dry_run: bool = False) -> dict[str, int | bool]:
+def migrate_app_store(
+    source: str | Path, target_url: str, dry_run: bool = False
+) -> dict[str, int | bool]:
     source = str(source)
     with sqlite3.connect(source) as source_conn:
         source_conn.row_factory = sqlite3.Row
         runs = source_conn.execute("SELECT * FROM runs").fetchall()
         datasets = source_conn.execute("SELECT * FROM datasets").fetchall()
-        table_names = {row[0] for row in source_conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-        snapshots = source_conn.execute("SELECT * FROM analysis_snapshots").fetchall() if "analysis_snapshots" in table_names else []
-        jobs = source_conn.execute("SELECT * FROM analysis_jobs").fetchall() if "analysis_jobs" in table_names else []
-        reports = source_conn.execute("SELECT * FROM analysis_reports").fetchall() if "analysis_reports" in table_names else []
+        table_names = {
+            row[0]
+            for row in source_conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        snapshots = (
+            source_conn.execute("SELECT * FROM analysis_snapshots").fetchall()
+            if "analysis_snapshots" in table_names
+            else []
+        )
+        jobs = (
+            source_conn.execute("SELECT * FROM analysis_jobs").fetchall()
+            if "analysis_jobs" in table_names
+            else []
+        )
+        reports = (
+            source_conn.execute("SELECT * FROM analysis_reports").fetchall()
+            if "analysis_reports" in table_names
+            else []
+        )
     if dry_run:
-        return {"dry_run": True, "runs": len(runs), "datasets": len(datasets), "snapshots": len(snapshots), "reports": len(reports)}
+        return {
+            "dry_run": True,
+            "runs": len(runs),
+            "datasets": len(datasets),
+            "snapshots": len(snapshots),
+            "reports": len(reports),
+        }
     if target_url.startswith("postgresql://"):
         target_url = target_url.replace("postgresql://", "postgresql+psycopg://", 1)
-    target_engine = create_engine(target_url, connect_args={"check_same_thread": False} if target_url.startswith("sqlite") else {}, pool_pre_ping=True if not target_url.startswith("sqlite") else False)
+    target_engine = create_engine(
+        target_url,
+        connect_args={"check_same_thread": False} if target_url.startswith("sqlite") else {},
+        pool_pre_ping=True if not target_url.startswith("sqlite") else False,
+    )
     SQLModel.metadata.create_all(target_engine)
     with Session(target_engine, expire_on_commit=False) as session:
         for row in runs:
             get = row.keys().__contains__
             request_json = row["request_json"] if get("request_json") else "{}"
-            session.merge(Run(
-                job_id=row["job_id"], study_name=row["study_name"], db_name=row["db_name"],
-                status=row["status"], request_json=request_json, started_at=row["started_at"],
-                completed_at=row["completed_at"], error=row["error"], best_value=row["best_value"],
-                best_params_json=row["best_params_json"], total_trials=row["total_trials"],
-                current_trial=row["current_trial"], session_id=row["session_id"] if get("session_id") else None,
-                user_id=row["user_id"] if get("user_id") else None,
-                dataset_id=row["dataset_id"] if get("dataset_id") else None,
-                source_file_id=row["source_file_id"] if get("source_file_id") else None,
-                source_file_path=row["source_file_path"] if get("source_file_path") else None,
-                study_storage_key=row["study_storage_key"] if get("study_storage_key") else row["db_name"],
-                artifact_storage=row["artifact_storage"] if get("artifact_storage") else "local",
-            ))
+            session.merge(
+                Run(
+                    job_id=row["job_id"],
+                    study_name=row["study_name"],
+                    db_name=row["db_name"],
+                    status=row["status"],
+                    request_json=request_json,
+                    started_at=row["started_at"],
+                    completed_at=row["completed_at"],
+                    error=row["error"],
+                    best_value=row["best_value"],
+                    best_params_json=row["best_params_json"],
+                    total_trials=row["total_trials"],
+                    current_trial=row["current_trial"],
+                    session_id=row["session_id"] if get("session_id") else None,
+                    user_id=row["user_id"] if get("user_id") else None,
+                    dataset_id=row["dataset_id"] if get("dataset_id") else None,
+                    source_file_id=row["source_file_id"] if get("source_file_id") else None,
+                    source_file_path=row["source_file_path"] if get("source_file_path") else None,
+                    study_storage_key=row["study_storage_key"]
+                    if get("study_storage_key")
+                    else row["db_name"],
+                    artifact_storage=row["artifact_storage"]
+                    if get("artifact_storage")
+                    else "local",
+                )
+            )
         for row in datasets:
             columns = row["columns_json"] if "columns_json" in row.keys() else "[]"
-            session.merge(Dataset(id=row["id"], name=row["name"], source=row["source"], file_path=row["file_path"], rows=row["rows"], columns_json=columns))
+            session.merge(
+                Dataset(
+                    id=row["id"],
+                    name=row["name"],
+                    source=row["source"],
+                    file_path=row["file_path"],
+                    rows=row["rows"],
+                    columns_json=columns,
+                )
+            )
         for row in snapshots:
             get = row.keys().__contains__
-            session.merge(AnalysisSnapshot(
-                id=row["id"], optimization_id=row["optimization_id"], config_key=row["config_key"],
-                config_json=row["config_json"], revision=row["revision"], payload_json=row["payload_json"],
-                artifact_dir=row["artifact_dir"], storage_backend=row["storage_backend"] if get("storage_backend") else "local",
-                artifact_prefix=row["artifact_prefix"] if get("artifact_prefix") else None,
-                created_at=row["created_at"], completed_at=row["completed_at"],
-            ))
+            session.merge(
+                AnalysisSnapshot(
+                    id=row["id"],
+                    optimization_id=row["optimization_id"],
+                    config_key=row["config_key"],
+                    config_json=row["config_json"],
+                    revision=row["revision"],
+                    payload_json=row["payload_json"],
+                    artifact_dir=row["artifact_dir"],
+                    storage_backend=row["storage_backend"] if get("storage_backend") else "local",
+                    artifact_prefix=row["artifact_prefix"] if get("artifact_prefix") else None,
+                    created_at=row["created_at"],
+                    completed_at=row["completed_at"],
+                )
+            )
         for row in jobs:
-            session.merge(AnalysisJob(id=row["id"], snapshot_id=row["snapshot_id"], status=row["status"],
-                                      current_section=row["current_section"], error=row["error"],
-                                      created_at=row["created_at"], completed_at=row["completed_at"]))
+            session.merge(
+                AnalysisJob(
+                    id=row["id"],
+                    snapshot_id=row["snapshot_id"],
+                    status=row["status"],
+                    current_section=row["current_section"],
+                    error=row["error"],
+                    created_at=row["created_at"],
+                    completed_at=row["completed_at"],
+                )
+            )
         for row in reports:
-            session.merge(AnalysisReport(id=row["id"], optimization_id=row["optimization_id"],
-                snapshot_id=row["snapshot_id"], snapshot_revision=row["snapshot_revision"], status=row["status"],
-                provider=row["provider"], model_name=row["model_name"], dataset_description=row["dataset_description"],
-                markdown=row["markdown"], error=row["error"], created_at=row["created_at"], completed_at=row["completed_at"]))
+            session.merge(
+                AnalysisReport(
+                    id=row["id"],
+                    optimization_id=row["optimization_id"],
+                    snapshot_id=row["snapshot_id"],
+                    snapshot_revision=row["snapshot_revision"],
+                    status=row["status"],
+                    provider=row["provider"],
+                    model_name=row["model_name"],
+                    dataset_description=row["dataset_description"],
+                    markdown=row["markdown"],
+                    error=row["error"],
+                    created_at=row["created_at"],
+                    completed_at=row["completed_at"],
+                )
+            )
         session.commit()
-    return {"dry_run": False, "runs": len(runs), "datasets": len(datasets), "snapshots": len(snapshots), "reports": len(reports)}
+    return {
+        "dry_run": False,
+        "runs": len(runs),
+        "datasets": len(datasets),
+        "snapshots": len(snapshots),
+        "reports": len(reports),
+    }

--- a/src/quoptuna/server/services/migration.py
+++ b/src/quoptuna/server/services/migration.py
@@ -1,0 +1,70 @@
+"""Idempotent migration of the legacy application SQLite store."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlmodel import Session, SQLModel
+
+from quoptuna.server.services.models import AnalysisJob, AnalysisReport, AnalysisSnapshot, Dataset, Run
+
+
+def migrate_app_store(source: str | Path, target_url: str, dry_run: bool = False) -> dict[str, int | bool]:
+    source = str(source)
+    with sqlite3.connect(source) as source_conn:
+        source_conn.row_factory = sqlite3.Row
+        runs = source_conn.execute("SELECT * FROM runs").fetchall()
+        datasets = source_conn.execute("SELECT * FROM datasets").fetchall()
+        table_names = {row[0] for row in source_conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        snapshots = source_conn.execute("SELECT * FROM analysis_snapshots").fetchall() if "analysis_snapshots" in table_names else []
+        jobs = source_conn.execute("SELECT * FROM analysis_jobs").fetchall() if "analysis_jobs" in table_names else []
+        reports = source_conn.execute("SELECT * FROM analysis_reports").fetchall() if "analysis_reports" in table_names else []
+    if dry_run:
+        return {"dry_run": True, "runs": len(runs), "datasets": len(datasets), "snapshots": len(snapshots), "reports": len(reports)}
+    if target_url.startswith("postgresql://"):
+        target_url = target_url.replace("postgresql://", "postgresql+psycopg://", 1)
+    target_engine = create_engine(target_url, connect_args={"check_same_thread": False} if target_url.startswith("sqlite") else {}, pool_pre_ping=True if not target_url.startswith("sqlite") else False)
+    SQLModel.metadata.create_all(target_engine)
+    with Session(target_engine, expire_on_commit=False) as session:
+        for row in runs:
+            get = row.keys().__contains__
+            request_json = row["request_json"] if get("request_json") else "{}"
+            session.merge(Run(
+                job_id=row["job_id"], study_name=row["study_name"], db_name=row["db_name"],
+                status=row["status"], request_json=request_json, started_at=row["started_at"],
+                completed_at=row["completed_at"], error=row["error"], best_value=row["best_value"],
+                best_params_json=row["best_params_json"], total_trials=row["total_trials"],
+                current_trial=row["current_trial"], session_id=row["session_id"] if get("session_id") else None,
+                user_id=row["user_id"] if get("user_id") else None,
+                dataset_id=row["dataset_id"] if get("dataset_id") else None,
+                source_file_id=row["source_file_id"] if get("source_file_id") else None,
+                source_file_path=row["source_file_path"] if get("source_file_path") else None,
+                study_storage_key=row["study_storage_key"] if get("study_storage_key") else row["db_name"],
+                artifact_storage=row["artifact_storage"] if get("artifact_storage") else "local",
+            ))
+        for row in datasets:
+            columns = row["columns_json"] if "columns_json" in row.keys() else "[]"
+            session.merge(Dataset(id=row["id"], name=row["name"], source=row["source"], file_path=row["file_path"], rows=row["rows"], columns_json=columns))
+        for row in snapshots:
+            get = row.keys().__contains__
+            session.merge(AnalysisSnapshot(
+                id=row["id"], optimization_id=row["optimization_id"], config_key=row["config_key"],
+                config_json=row["config_json"], revision=row["revision"], payload_json=row["payload_json"],
+                artifact_dir=row["artifact_dir"], storage_backend=row["storage_backend"] if get("storage_backend") else "local",
+                artifact_prefix=row["artifact_prefix"] if get("artifact_prefix") else None,
+                created_at=row["created_at"], completed_at=row["completed_at"],
+            ))
+        for row in jobs:
+            session.merge(AnalysisJob(id=row["id"], snapshot_id=row["snapshot_id"], status=row["status"],
+                                      current_section=row["current_section"], error=row["error"],
+                                      created_at=row["created_at"], completed_at=row["completed_at"]))
+        for row in reports:
+            session.merge(AnalysisReport(id=row["id"], optimization_id=row["optimization_id"],
+                snapshot_id=row["snapshot_id"], snapshot_revision=row["snapshot_revision"], status=row["status"],
+                provider=row["provider"], model_name=row["model_name"], dataset_description=row["dataset_description"],
+                markdown=row["markdown"], error=row["error"], created_at=row["created_at"], completed_at=row["completed_at"]))
+        session.commit()
+    return {"dry_run": False, "runs": len(runs), "datasets": len(datasets), "snapshots": len(snapshots), "reports": len(reports)}

--- a/src/quoptuna/server/services/migration.py
+++ b/src/quoptuna/server/services/migration.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import sqlite3
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from sqlalchemy import create_engine
 from sqlmodel import Session, SQLModel
@@ -58,12 +60,13 @@ def migrate_app_store(
     target_engine = create_engine(
         target_url,
         connect_args={"check_same_thread": False} if target_url.startswith("sqlite") else {},
-        pool_pre_ping=True if not target_url.startswith("sqlite") else False,
+        pool_pre_ping=not target_url.startswith("sqlite"),
     )
     SQLModel.metadata.create_all(target_engine)
     with Session(target_engine, expire_on_commit=False) as session:
         for row in runs:
-            get = row.keys().__contains__
+            row_keys = set(row.keys())
+            get = row_keys.__contains__
             request_json = row["request_json"] if get("request_json") else "{}"
             session.merge(
                 Run(
@@ -93,7 +96,8 @@ def migrate_app_store(
                 )
             )
         for row in datasets:
-            columns = row["columns_json"] if "columns_json" in row.keys() else "[]"
+            row_keys = set(row.keys())
+            columns = row["columns_json"] if "columns_json" in row_keys else "[]"
             session.merge(
                 Dataset(
                     id=row["id"],
@@ -105,7 +109,8 @@ def migrate_app_store(
                 )
             )
         for row in snapshots:
-            get = row.keys().__contains__
+            row_keys = set(row.keys())
+            get = row_keys.__contains__
             session.merge(
                 AnalysisSnapshot(
                     id=row["id"],

--- a/src/quoptuna/server/services/models.py
+++ b/src/quoptuna/server/services/models.py
@@ -1,0 +1,101 @@
+"""SQLModel tables owned by QuOptuna."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Run(SQLModel, table=True):
+    __tablename__ = "quoptuna_runs"
+    job_id: str = Field(primary_key=True)
+    study_name: Optional[str] = None
+    db_name: Optional[str] = None
+    status: Optional[str] = None
+    request_json: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    error: Optional[str] = None
+    best_value: Optional[float] = None
+    best_params_json: Optional[str] = None
+    total_trials: Optional[int] = None
+    current_trial: Optional[int] = None
+    session_id: Optional[str] = Field(default=None, index=True)
+    user_id: Optional[str] = Field(default=None, index=True)
+    dataset_id: Optional[str] = None
+    source_file_id: Optional[str] = None
+    source_file_path: Optional[str] = None
+    source_object_key: Optional[str] = None
+    study_storage_key: Optional[str] = None
+    artifact_storage: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Dataset(SQLModel, table=True):
+    __tablename__ = "quoptuna_datasets"
+    id: str = Field(primary_key=True)
+    name: Optional[str] = None
+    source: Optional[str] = None
+    file_path: Optional[str] = None
+    object_key: Optional[str] = None
+    checksum: Optional[str] = None
+    rows: Optional[int] = None
+    columns_json: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class AnalysisSnapshot(SQLModel, table=True):
+    __tablename__ = "quoptuna_analysis_snapshots"
+    id: str = Field(primary_key=True)
+    optimization_id: str = Field(index=True)
+    config_key: str
+    config_json: str
+    revision: int = 0
+    payload_json: Optional[str] = None
+    artifact_dir: Optional[str] = None
+    storage_backend: Optional[str] = None
+    artifact_prefix: Optional[str] = None
+    created_at: str = ""
+    completed_at: Optional[str] = None
+
+
+class AnalysisJob(SQLModel, table=True):
+    __tablename__ = "quoptuna_analysis_jobs"
+    id: str = Field(primary_key=True)
+    snapshot_id: str = Field(index=True)
+    status: str
+    current_section: Optional[str] = None
+    error: Optional[str] = None
+    created_at: str = ""
+    completed_at: Optional[str] = None
+
+
+class AnalysisReport(SQLModel, table=True):
+    __tablename__ = "quoptuna_analysis_reports"
+    id: str = Field(primary_key=True)
+    optimization_id: str
+    snapshot_id: str = Field(index=True)
+    snapshot_revision: int
+    status: str
+    provider: str
+    model_name: str
+    dataset_description: Optional[str] = None
+    markdown: Optional[str] = None
+    error: Optional[str] = None
+    created_at: str = ""
+    completed_at: Optional[str] = None
+
+
+class AnalysisArtifact(SQLModel, table=True):
+    __tablename__ = "quoptuna_analysis_artifacts"
+    id: str = Field(primary_key=True)
+    optimization_id: str = Field(index=True)
+    snapshot_id: str = Field(index=True)
+    revision: int
+    filename: str
+    object_key: Optional[str] = None
+    storage_backend: str = "local"
+    mime_type: Optional[str] = None
+    size_bytes: Optional[int] = None
+    checksum: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/src/quoptuna/server/services/run_store.py
+++ b/src/quoptuna/server/services/run_store.py
@@ -1,167 +1,121 @@
-"""
-Durable store for optimization runs and dataset records.
-
-Persists the state that previously lived only in in-memory dicts
-(``optimization_jobs`` and the dataset registry) into a small app-level
-SQLite database, so runs survive backend restarts and can be listed,
-rehydrated, and replayed from the UI.
-"""
+"""Durable SQLModel store for runs and datasets."""
 
 import json
-import sqlite3
 from typing import Any, Dict, List, Optional
 
-from quoptuna.server.services.storage import ensure_db_dir
+from sqlmodel import select
 
+from quoptuna.server.services.database import session_scope
+from quoptuna.server.services.models import Dataset, Run
+
+# Retained as a compatibility hook for existing tests and local deployments.
 APP_DB_PATH = "db/quoptuna_app.db"
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS runs (
-    job_id TEXT PRIMARY KEY,
-    study_name TEXT,
-    db_name TEXT,
-    status TEXT,
-    request_json TEXT,
-    started_at TEXT,
-    completed_at TEXT,
-    error TEXT,
-    best_value REAL,
-    best_params_json TEXT,
-    total_trials INTEGER,
-    current_trial INTEGER
-);
-CREATE TABLE IF NOT EXISTS datasets (
-    id TEXT PRIMARY KEY,
-    name TEXT,
-    source TEXT,
-    file_path TEXT,
-    rows INTEGER,
-    columns_json TEXT
-);
-"""
 
-_RUN_COLUMNS = (
-    "job_id",
-    "study_name",
-    "db_name",
-    "status",
-    "request_json",
-    "started_at",
-    "completed_at",
-    "error",
-    "best_value",
-    "best_params_json",
-    "total_trials",
-    "current_trial",
-)
-
-
-def _connect() -> sqlite3.Connection:
-    ensure_db_dir()
-    conn = sqlite3.connect(APP_DB_PATH)
-    conn.row_factory = sqlite3.Row
-    conn.executescript(_SCHEMA)
-    return conn
-
-
-def _row_to_run(row: sqlite3.Row) -> Dict[str, Any]:
-    run = dict(row)
-    run["request"] = json.loads(run.pop("request_json") or "null")
-    run["best_params"] = json.loads(run.pop("best_params_json") or "null")
-    return run
+def _run_dict(row: Run) -> Dict[str, Any]:
+    result = row.model_dump()
+    result["request"] = json.loads(result.pop("request_json") or "null")
+    result["best_params"] = json.loads(result.pop("best_params_json") or "null")
+    result["id"] = result["job_id"]
+    return result
 
 
 def save_run(job: Dict[str, Any]) -> None:
-    """Insert or replace a run row from a job dict (as kept in memory)."""
     request = job.get("request") or {}
-    values = (
-        job["id"],
-        request.get("study_name"),
-        request.get("database_name"),
-        job.get("status"),
-        json.dumps(request),
-        job.get("started_at"),
-        job.get("completed_at"),
-        job.get("error"),
-        job.get("best_value"),
-        json.dumps(job.get("best_params")),
-        job.get("total_trials"),
-        job.get("current_trial"),
+    values = Run(
+        job_id=job["id"], study_name=request.get("study_name"),
+        db_name=request.get("database_name"), status=job.get("status"),
+        request_json=json.dumps(request), started_at=job.get("started_at"),
+        completed_at=job.get("completed_at"), error=job.get("error"),
+        best_value=job.get("best_value"), best_params_json=json.dumps(job.get("best_params")),
+        total_trials=job.get("total_trials"), current_trial=job.get("current_trial"),
+        session_id=job.get("session_id"), user_id=job.get("user_id"),
+        dataset_id=request.get("dataset_id"),
+        source_file_id=job.get("source_file_id") or request.get("dataset_id"),
+        source_file_path=job.get("source_file_path"),
+        study_storage_key=job.get("study_storage_key"),
+        artifact_storage=job.get("artifact_storage"),
     )
-    with _connect() as conn:
-        placeholders = ",".join("?" for _ in _RUN_COLUMNS)
-        conn.execute(
-            # Column names come from the module-level _RUN_COLUMNS constant.
-            f"INSERT OR REPLACE INTO runs ({','.join(_RUN_COLUMNS)}) VALUES ({placeholders})",  # noqa: S608
-            values,
-        )
+    with session_scope() as session:
+        existing = session.get(Run, values.job_id)
+        if existing:
+            for key, value in values.model_dump(exclude={"job_id", "created_at"}).items():
+                setattr(existing, key, value)
+            session.add(existing)
+        else:
+            session.add(values)
+        session.commit()
 
 
 def update_run(job_id: str, **fields: Any) -> None:
-    """Update selected columns of a run row."""
     if "best_params" in fields:
         fields["best_params_json"] = json.dumps(fields.pop("best_params"))
-    if not fields:
-        return
-    unknown = set(fields) - set(_RUN_COLUMNS)
+    allowed = set(Run.model_fields) - {"job_id", "created_at"}
+    unknown = set(fields) - allowed
     if unknown:
         raise ValueError(f"Unknown run columns: {unknown}")
-    assignments = ",".join(f"{key} = ?" for key in fields)
-    with _connect() as conn:
-        conn.execute(
-            # Column names are validated against _RUN_COLUMNS above.
-            f"UPDATE runs SET {assignments} WHERE job_id = ?",  # noqa: S608
-            (*fields.values(), job_id),
-        )
+    with session_scope() as session:
+        row = session.get(Run, job_id)
+        if row is None:
+            return
+        for key, value in fields.items():
+            setattr(row, key, value)
+        session.add(row)
+        session.commit()
 
 
 def get_run(job_id: str) -> Optional[Dict[str, Any]]:
-    with _connect() as conn:
-        row = conn.execute("SELECT * FROM runs WHERE job_id = ?", (job_id,)).fetchone()
-    return _row_to_run(row) if row else None
+    with session_scope() as session:
+        row = session.get(Run, job_id)
+        return _run_dict(row) if row else None
 
 
 def list_runs() -> List[Dict[str, Any]]:
-    with _connect() as conn:
-        rows = conn.execute("SELECT * FROM runs ORDER BY started_at DESC").fetchall()
-    return [_row_to_run(row) for row in rows]
+    with session_scope() as session:
+        rows = session.exec(select(Run).order_by(Run.started_at.desc())).all()
+        return [_run_dict(row) for row in rows]
 
 
 def delete_run(job_id: str) -> None:
-    with _connect() as conn:
-        conn.execute("DELETE FROM runs WHERE job_id = ?", (job_id,))
+    with session_scope() as session:
+        row = session.get(Run, job_id)
+        if row:
+            session.delete(row)
+            session.commit()
 
 
 def mark_stale_runs_interrupted() -> None:
-    """Mark runs left 'running'/'pending' by a dead process as interrupted."""
-    with _connect() as conn:
-        conn.execute(
-            "UPDATE runs SET status = 'interrupted' WHERE status IN ('running', 'pending')"
-        )
+    with session_scope() as session:
+        rows = session.exec(select(Run).where(Run.status.in_(["running", "pending"]))).all()
+        for row in rows:
+            row.status = "interrupted"
+            session.add(row)
+        session.commit()
 
 
 def save_dataset(record: Dict[str, Any]) -> None:
-    with _connect() as conn:
-        conn.execute(
-            "INSERT OR REPLACE INTO datasets (id, name, source, file_path, rows, columns_json)"
-            " VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                record["id"],
-                record.get("name"),
-                record.get("source"),
-                record.get("file_path"),
-                record.get("rows"),
-                json.dumps(record.get("columns")),
-            ),
-        )
+    values = Dataset(
+        id=record["id"], name=record.get("name"), source=record.get("source"),
+        file_path=record.get("file_path"), object_key=record.get("object_key"),
+        checksum=record.get("checksum"), rows=record.get("rows"),
+        columns_json=json.dumps(record.get("columns")),
+    )
+    with session_scope() as session:
+        existing = session.get(Dataset, values.id)
+        if existing:
+            for key, value in values.model_dump(exclude={"id", "created_at"}).items():
+                setattr(existing, key, value)
+            session.add(existing)
+        else:
+            session.add(values)
+        session.commit()
 
 
 def all_datasets() -> List[Dict[str, Any]]:
-    with _connect() as conn:
-        rows = conn.execute("SELECT * FROM datasets").fetchall()
-    records = []
-    for row in rows:
-        record = dict(row)
-        record["columns"] = json.loads(record.pop("columns_json") or "[]")
-        records.append(record)
-    return records
+    with session_scope() as session:
+        records = []
+        for row in session.exec(select(Dataset)).all():
+            value = row.model_dump()
+            value["columns"] = json.loads(value.pop("columns_json") or "[]")
+            records.append(value)
+        return records

--- a/src/quoptuna/server/services/run_store.py
+++ b/src/quoptuna/server/services/run_store.py
@@ -23,13 +23,20 @@ def _run_dict(row: Run) -> Dict[str, Any]:
 def save_run(job: Dict[str, Any]) -> None:
     request = job.get("request") or {}
     values = Run(
-        job_id=job["id"], study_name=request.get("study_name"),
-        db_name=request.get("database_name"), status=job.get("status"),
-        request_json=json.dumps(request), started_at=job.get("started_at"),
-        completed_at=job.get("completed_at"), error=job.get("error"),
-        best_value=job.get("best_value"), best_params_json=json.dumps(job.get("best_params")),
-        total_trials=job.get("total_trials"), current_trial=job.get("current_trial"),
-        session_id=job.get("session_id"), user_id=job.get("user_id"),
+        job_id=job["id"],
+        study_name=request.get("study_name"),
+        db_name=request.get("database_name"),
+        status=job.get("status"),
+        request_json=json.dumps(request),
+        started_at=job.get("started_at"),
+        completed_at=job.get("completed_at"),
+        error=job.get("error"),
+        best_value=job.get("best_value"),
+        best_params_json=json.dumps(job.get("best_params")),
+        total_trials=job.get("total_trials"),
+        current_trial=job.get("current_trial"),
+        session_id=job.get("session_id"),
+        user_id=job.get("user_id"),
         dataset_id=request.get("dataset_id"),
         source_file_id=job.get("source_file_id") or request.get("dataset_id"),
         source_file_path=job.get("source_file_path"),
@@ -95,9 +102,13 @@ def mark_stale_runs_interrupted() -> None:
 
 def save_dataset(record: Dict[str, Any]) -> None:
     values = Dataset(
-        id=record["id"], name=record.get("name"), source=record.get("source"),
-        file_path=record.get("file_path"), object_key=record.get("object_key"),
-        checksum=record.get("checksum"), rows=record.get("rows"),
+        id=record["id"],
+        name=record.get("name"),
+        source=record.get("source"),
+        file_path=record.get("file_path"),
+        object_key=record.get("object_key"),
+        checksum=record.get("checksum"),
+        rows=record.get("rows"),
         columns_json=json.dumps(record.get("columns")),
     )
     with session_scope() as session:

--- a/src/quoptuna/server/services/run_store.py
+++ b/src/quoptuna/server/services/run_store.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, Dict, List, Optional
 
-from sqlmodel import select
+from sqlmodel import col, select
 
 from quoptuna.server.services.database import session_scope
 from quoptuna.server.services.models import Dataset, Run
@@ -79,7 +79,7 @@ def get_run(job_id: str) -> Optional[Dict[str, Any]]:
 
 def list_runs() -> List[Dict[str, Any]]:
     with session_scope() as session:
-        rows = session.exec(select(Run).order_by(Run.started_at.desc())).all()
+        rows = session.exec(select(Run).order_by(col(Run.started_at).desc())).all()
         return [_run_dict(row) for row in rows]
 
 
@@ -93,7 +93,7 @@ def delete_run(job_id: str) -> None:
 
 def mark_stale_runs_interrupted() -> None:
     with session_scope() as session:
-        rows = session.exec(select(Run).where(Run.status.in_(["running", "pending"]))).all()
+        rows = session.exec(select(Run).where(col(Run.status).in_(["running", "pending"]))).all()
         for row in rows:
             row.status = "interrupted"
             session.add(row)

--- a/uv.lock
+++ b/uv.lock
@@ -354,6 +354,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/da/0e90eab875f2eb4b8708fef2c198f2559ed1e451a1016f1cd4fcdcfbfbe3/boto3-1.43.53.tar.gz", hash = "sha256:c80425acab314d7af09609562053f565139e1fe49108eacfcc1601ebfaee235b", size = 112678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/27/7e72d25fdde77668b7bd4fa47381192dd2aa64fb77265e4bab786fd9fe2a/boto3-1.43.53-py3-none-any.whl", hash = "sha256:5383e705d8a976a14f23bb8c113c07a396931a019db98fce4cdc68650ec6e4d8", size = 140025 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/6b/ebcefacc4de3cd4f1c449540d86877f76c2f5e586a620831012decbb2b2c/botocore-1.43.53.tar.gz", hash = "sha256:36d93dd8db68ee75f6b61ca9f775161b8168844e4601698701530e6efdded141", size = 15720336 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/e5/1b60e394f0fff97ee70dd16913382b7dffda85b98e639c0c9e8ff56cfaa7/botocore-1.43.53-py3-none-any.whl", hash = "sha256:b7ee9a70d187e5348883c820990ccd9436ab14e2bd6622741fc96fe561e816b8", size = 15404628 },
+]
+
+[[package]]
 name = "bottle"
 version = "0.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1459,6 +1487,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443 },
     { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039 },
     { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613 },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419 },
 ]
 
 [[package]]
@@ -2760,6 +2797,53 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001 },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813 },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799 },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050 },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428 },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746 },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033 },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175 },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203 },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509 },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551 },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054 },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122 },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943 },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697 },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995 },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180 },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828 },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757 },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546 },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197 },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627 },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782 },
+]
+
+[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3130,6 +3214,7 @@ version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "auth0-server-python" },
+    { name = "boto3" },
     { name = "codeflash" },
     { name = "fairlearn" },
     { name = "fastapi" },
@@ -3152,6 +3237,7 @@ dependencies = [
     { name = "plotly" },
     { name = "pmlb" },
     { name = "pre-commit" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytest" },
@@ -3164,6 +3250,7 @@ dependencies = [
     { name = "scipy" },
     { name = "seaborn" },
     { name = "shap" },
+    { name = "sqlmodel" },
     { name = "streamlit" },
     { name = "streamlit-elements" },
     { name = "typer" },
@@ -3174,6 +3261,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "auth0-server-python", specifier = ">=1.0.0b1,<2" },
+    { name = "boto3", specifier = ">=1.35.0,<2.0.0" },
     { name = "codeflash", specifier = ">=0.8.3" },
     { name = "fairlearn", specifier = ">=0.11.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -3196,6 +3284,7 @@ requires-dist = [
     { name = "plotly", specifier = "==5.24.1" },
     { name = "pmlb", specifier = ">=1.0.1.post3" },
     { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0,<4.0.0" },
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
@@ -3208,6 +3297,7 @@ requires-dist = [
     { name = "scipy", specifier = "==1.14.1" },
     { name = "seaborn", specifier = "==0.13.2" },
     { name = "shap", specifier = "==0.46.0" },
+    { name = "sqlmodel", specifier = ">=0.0.22,<0.1.0" },
     { name = "streamlit", specifier = "==1.38.0" },
     { name = "streamlit-elements", specifier = "==0.1.0" },
     { name = "typer", specifier = ">=0.12.0" },
@@ -3428,6 +3518,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072 },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3644,6 +3746,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483 },
     { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494 },
     { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158 },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.39"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ee/22a0559283c3cf6048678e787ed5d4959dcd00dedd8ba4567eeae684eeb1/sqlmodel-0.0.39.tar.gz", hash = "sha256:23d8e50a8d8ee936032ed79c55023a5d618dd6bc3c510bbf4909d1a7a605a570", size = 91057 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/7d/b9813a582d4eb310be35e1fc7dfaae71207d7b62e9e53be314ebd251b53b/sqlmodel-0.0.39-py3-none-any.whl", hash = "sha256:90ebe92ce5cc11d7fff8dc7cb594790a102333c8fe7c14865254f6fc5c939795", size = 29680 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3210,7 +3210,7 @@ wheels = [
 
 [[package]]
 name = "quoptuna"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "auth0-server-python" },


### PR DESCRIPTION
This pull request introduces several major improvements to the application's backend, focusing on enhanced artifact storage, S3 integration, and a migration to SQLModel for analysis job persistence. It also adds support for richer metadata tracking in optimization jobs and dataset uploads. The most important changes are grouped below:

**Artifact Storage and S3 Integration**
* Added configuration for S3 and local artifact storage via new environment variables and settings in `.env.example` and `src/quoptuna/server/core/config.py`, enabling flexible artifact management across deployments. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR5-R17) [[2]](diffhunk://#diff-ace29100d9f3425b25f82d47965c4cb38281ccd6ff0c5961cdf73027b882474cL34-R46)
* Implemented S3 artifact upload for dataset files and the ability to generate signed URLs for artifact access, including new endpoints and logic in the API and artifact store utilities. [[1]](diffhunk://#diff-c386dc75f1cc8fbd990c6cb931b7f82504bf5eb1b9d797e14050fbb46b4f7cc9R93-R106) [[2]](diffhunk://#diff-c386dc75f1cc8fbd990c6cb931b7f82504bf5eb1b9d797e14050fbb46b4f7cc9R119) [[3]](diffhunk://#diff-c421593c96029b44edb0f5982933e9f977b70301ff18a210f7b750d0f06a173eR594-R607)

**Database and Analysis Job Persistence**
* Refactored analysis job and snapshot persistence from SQLite direct SQL to SQLModel-based models and sessions, improving maintainability and enabling PostgreSQL support. [[1]](diffhunk://#diff-6b1556da5ead9928e38722cf703357cb28994bd710068f2785ee37ecef17de64R14-R26) [[2]](diffhunk://#diff-6b1556da5ead9928e38722cf703357cb28994bd710068f2785ee37ecef17de64L91-R113)
* Added PostgreSQL schema isolation for Optuna and improved database URL handling to support multiple backends, including migration helpers for legacy data. [[1]](diffhunk://#diff-b7e9db360ac31b098e866f4b24febaa855ade4f0a34347ec8e1c4210e7bd9a34R47-R72) [[2]](diffhunk://#diff-b7e9db360ac31b098e866f4b24febaa855ade4f0a34347ec8e1c4210e7bd9a34R12-R13) [[3]](diffhunk://#diff-45b7bec1a5dfbced04b8edae414a307b186d0413f6a6aa64b79d81023f0d4767R388-R403)

**Optimization Job Metadata**
* Extended the optimization job tracking to include `session_id`, `user_id`, source file info, and artifact storage backend, providing richer context for each job and improving traceability. [[1]](diffhunk://#diff-64894e1a4561857ecc0316f7ca3c832c025deb8536acb7eeca0e6a68a4ee159cR41-R42) [[2]](diffhunk://#diff-64894e1a4561857ecc0316f7ca3c832c025deb8536acb7eeca0e6a68a4ee159cR350-R352) [[3]](diffhunk://#diff-64894e1a4561857ecc0316f7ca3c832c025deb8536acb7eeca0e6a68a4ee159cR366-R371) [[4]](diffhunk://#diff-64894e1a4561857ecc0316f7ca3c832c025deb8536acb7eeca0e6a68a4ee159cR441-R445)

**Dependency and Configuration Updates**
* Added new dependencies for SQLModel, PostgreSQL, and S3 support in `pyproject.toml`.
* Updated default database paths and configuration to align with new storage patterns and deployment best practices. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L30-R31) [[2]](diffhunk://#diff-ace29100d9f3425b25f82d47965c4cb38281ccd6ff0c5961cdf73027b882474cL34-R46)

**Codebase Cleanup**
* Removed legacy SQLite schema and connection code from the analysis store, clarifying the service's responsibilities and reducing technical debt. [[1]](diffhunk://#diff-6b1556da5ead9928e38722cf703357cb28994bd710068f2785ee37ecef17de64R14-R26) [[2]](diffhunk://#diff-6b1556da5ead9928e38722cf703357cb28994bd710068f2785ee37ecef17de64L91-R113)

These changes collectively modernize the backend, improve cloud compatibility, and lay the groundwork for scalable artifact and job management.
__________
Replace the legacy SQLite app store with SQLModel-backed persistence and add S3 artifact storage.

Key changes:
- Introduce SQLModel models, engine/session (services/models.py, services/database.py).
- Refactor run_store and analysis_store to use SQLModel; add artifact table and S3ArtifactStore with presigned URLs.
- Add migration tooling (services/migration.py) and CLI command migrate-supabase.
- Add Optuna helpers (ensure_optuna_schema, optuna_storage_url) and session/schema support.
- Persist dataset object_key on upload and expose artifact endpoint and artifact_url lookup.
- Update settings, .env.example, docker-compose paths, and dependencies (sqlmodel, psycopg[binary], boto3).

