### PR TITLE
fix: Expand docs for infra and model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Documented the `quoptuna infra`, `active-work`, and `deployment-check` CLI commands.
+- New "Deploy the AWS infrastructure" how-to covering prerequisites, the deployment
+  file, the Textual console options, every operation and script flag, and troubleshooting.
+- Documented `AUTH_ALLOWED_EMAILS`, `AUTH_REQUIRE_VERIFIED_EMAIL`, and `APP_ENV`,
+  including the production start-up check and the public `/api/v1/health` path.
+- Added `QuantumBoltzmannMachine` to the model catalog and a new image-shaped models
+  section for `QuanvolutionalNeuralNetwork`, `WeiNet`, and `ConvolutionalNeuralNetwork`.
+
+### Changed
+- Clarified that the model catalog lists registry keys, while `/api/v1/models`
+  returns display names.
 
 ## [0.1.3]
 ### Changed

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
             { slug: "how-to/use-multiclass" },
             { slug: "how-to/generate-reports" },
             { slug: "how-to/migrate-to-supabase" },
+            { slug: "how-to/deploy-infrastructure" },
             { slug: "how-to/deploy-this-site" },
           ],
         },

--- a/docs-site/src/components/Landing.astro
+++ b/docs-site/src/components/Landing.astro
@@ -59,7 +59,7 @@ const REPO = "https://github.com/Qentora/quoptuna";
   <div class="qo-wrap">
     <div class="qo-star-inner">
       <div>
-        <div class="qo-eyebrow">Open source · MIT</div>
+        <div class="qo-eyebrow">Open source · Apache 2.0</div>
         <h2>Star it if it saved you a trial.</h2>
         <p>Stars help other researchers find QuOptuna and steer what we build next.</p>
       </div>

--- a/docs-site/src/content/docs/how-to/deploy-infrastructure.md
+++ b/docs-site/src/content/docs/how-to/deploy-infrastructure.md
@@ -1,0 +1,222 @@
+---
+title: Deploy the AWS infrastructure
+description: Prerequisites, the quoptuna infra console, and the create/deploy/pause/resume/destroy operations.
+---
+
+QuOptuna deploys as a single stoppable EC2 instance running the application
+container behind Caddy. Supabase stores application and Optuna data, and S3
+stores datasets and analysis artifacts. There is no Kubernetes cluster, load
+balancer, NAT Gateway, RDS instance, or open SSH port.
+
+Terraform lives in `infra/terraform/` (a `foundation` stack for persistent
+resources and an `application` stack for compute), and every operation is driven
+by the scripts in `infra/scripts/`.
+
+## Prerequisites
+
+### Tooling
+
+| Requirement | Notes |
+| --- | --- |
+| Terraform | `>= 1.10.0, < 2.0.0` (pinned in `versions.tf`) |
+| AWS CLI v2 | Authenticated; `aws sts get-caller-identity` must succeed |
+| Docker with Buildx | Used to build and push the immutable application image |
+| `jq` | Required by the operation scripts |
+| `git` | Used to stamp the deployed image |
+| `curl`, Python 3 | Health checks and deployment-file parsing |
+
+The scripts check for `aws`, `terraform`, `jq`, `docker`, and `git`, and fail
+with `Required command not found` if any is missing.
+
+### Accounts and resources
+
+- **AWS account** with permissions for EC2, S3, ECR, Route 53, Secrets Manager,
+  IAM, and SSM.
+- **Supabase PostgreSQL URL**. The EC2 network is dual-stack, so Supabase's
+  IPv6-only direct endpoint works. An IPv4-compatible session-pooler URL with
+  `sslmode=require` is also supported.
+- **A domain** registered anywhere and delegated to an existing Route 53 hosted
+  zone. You need the zone ID.
+- **An Auth0 application** (see [Auth0 setup](#auth0-setup) below).
+- **A globally unique S3 bucket name** for Terraform state. The scripts create
+  the bucket if it does not exist, with versioning, encryption, and public-access
+  blocking enabled.
+
+### The deployment file
+
+Copy the template and fill it in:
+
+```bash
+cp .env.deploy.example .env.deploy
+aws sts get-caller-identity
+```
+
+`infra/scripts/envfile.py` parses this file as a conservative `KEY=VALUE` subset
+— it never evaluates shell syntax. Matching variables already present in your
+process environment take precedence over the file.
+
+**Deployment keys** (control where and how infrastructure is built):
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `AWS_PROFILE` | `default` | Profile for the AWS credential chain |
+| `AWS_REGION` | `us-east-2` | Target region |
+| `TF_STATE_BUCKET` | — | Globally unique Terraform state bucket |
+| `PROJECT_NAME` | `quoptuna` | Resource name prefix |
+| `DOMAIN_NAME` | `quoptuna.example.com` | Public hostname served over HTTPS |
+| `ROUTE53_ZONE_ID` | `Z0000...` | Hosted zone for the domain |
+| `INSTANCE_TYPE` | `t3.large` | EC2 instance size |
+| `ROOT_VOLUME_SIZE` | `50` | Root EBS volume in GB |
+
+**Runtime keys** (written into the AWS Secrets Manager runtime secret):
+
+`DATABASE_URL`, `OPTUNA_DATABASE_URL`, `OPTUNA_DB_SCHEMA`, `AUTH0_DOMAIN`,
+`AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, `AUTH_ALLOWED_EMAILS`,
+`AUTH_REQUIRE_VERIFIED_EMAIL`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`GOOGLE_API_KEY`.
+
+See the [Configuration reference](/reference/configuration/) for what each
+runtime variable does.
+
+:::note
+The deployment derives `APP_ENV=production`, `APP_BASE_URL`, `CORS_ORIGINS`,
+`ARTIFACT_STORAGE=s3`, and the `S3_*` settings automatically from your domain,
+bucket, and region. Do not set them in `.env.deploy`.
+:::
+
+### Auth0 setup
+
+In the Auth0 application, set:
+
+- Allowed Callback URL: `https://YOUR_DOMAIN/auth/callback`
+- Allowed Logout URL: `https://YOUR_DOMAIN`
+- Allowed Web Origin: `https://YOUR_DOMAIN`
+
+Then open **Actions → Library → Build Custom**, create a Post-Login Action, and
+paste `infra/auth0/approved-emails.js`. Add these Action secrets:
+
+- `QUOPTUNA_CLIENT_ID` — the QuOptuna Auth0 client ID
+- `ALLOWED_EMAILS` — the same comma-separated list as `AUTH_ALLOWED_EMAILS`
+
+Deploy the Action and add it to **Actions → Flows → Login**. QuOptuna repeats the
+same allowlist and verified-email checks in the API, so removing the Action does
+not open application access.
+
+## Run from the console
+
+```bash
+uv sync
+uv run quoptuna infra --environment dev --env-file .env.deploy
+```
+
+This opens a [Textual](https://textual.textualize.io/) console with an action
+sidebar, a live status panel, and a streaming log. Secrets matching
+`password`, `secret`, `token`, `database_url`, `access_key`, or `private_key`
+are redacted from the log output.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--environment`, `-e` | `dev` | Target environment (`dev` or `production`) |
+| `--env-file` | none | Deployment `.env` file; falls back to the process environment |
+| `--terraform-dir` | `infra` | Directory holding `scripts/` and `terraform/` |
+
+Key bindings: `r` refreshes status, `q` quits. Only one operation runs at a
+time. **Pause** asks for confirmation; **Destroy** requires you to type the
+environment name exactly.
+
+## Operations
+
+| Action | What it does |
+| --- | --- |
+| **Create** | State bootstrap, persistent resources, image build, EC2, DNS, and HTTPS |
+| **Deploy** | Build and deploy a new immutable image |
+| **Update** | Apply Terraform changes and deploy the new image |
+| **Pause** | Refuse while work is active, remove DNS, and stop EC2 |
+| **Resume** | Start EC2, restore DNS, and wait for HTTPS |
+| **Status** | Report EC2 state, app health, image, and active work |
+| **Destroy** | Delete compute/network resources, preserving Supabase and AWS data |
+
+The same operations run directly as scripts:
+
+```bash
+infra/scripts/create.sh dev --env-file .env.deploy
+infra/scripts/status.sh dev --env-file .env.deploy --json
+infra/scripts/pause.sh dev --env-file .env.deploy
+infra/scripts/resume.sh dev --env-file .env.deploy
+infra/scripts/deploy.sh dev --env-file .env.deploy
+infra/scripts/update.sh dev --env-file .env.deploy
+infra/scripts/destroy.sh dev --env-file .env.deploy
+```
+
+:::caution
+The environment argument accepts only `dev` or `production`. Any other value
+fails with `Unsupported environment`.
+:::
+
+### Script options
+
+| Flag | Applies to | Purpose |
+| --- | --- | --- |
+| `--env-file PATH` | all | Deployment file to read |
+| `--json` | `status` | Emit machine-readable status (used by the console) |
+| `--plan-only` | `create`, `update` | Show the Terraform plan without applying |
+| `--force` | `pause`, `destroy` | Proceed even though work is active |
+| `--confirm-destroy` | `destroy` | Skip the interactive destroy confirmation |
+| `--delete-data` | `destroy` | Also delete the persistent AWS foundation |
+
+Use `--force` only when you intentionally accept interrupting active trials.
+
+To delete the persistent AWS foundation too:
+
+```bash
+infra/scripts/destroy.sh dev --env-file .env.deploy --delete-data
+```
+
+This requires two typed confirmations. It deletes the artifact bucket, images,
+and runtime secret. It never deletes Supabase or the Terraform-state bucket.
+
+## Check deployment health
+
+Two CLI commands report on a running deployment, both emitting JSON:
+
+```bash
+quoptuna active-work        # active optimization and analysis counts
+quoptuna deployment-check   # readiness checks; exits 1 when unhealthy
+```
+
+`pause` calls `active-work` on the instance over SSM to refuse stopping EC2
+while trials are still running. See the [CLI reference](/reference/cli/).
+
+## Cost controls
+
+- Pause EC2 whenever trials are not running.
+- The default `t3.large` uses standard CPU credits, preventing unlimited-credit
+  charges.
+- No Elastic IP is retained while paused; DNS is restored to the new address on
+  resume.
+- ECR keeps only five images.
+- Old S3 artifacts transition to Glacier Instant Retrieval.
+- Container logs rotate locally; CloudWatch log ingestion is not enabled.
+- Increase `INSTANCE_TYPE` only for trials that need more CPU or memory.
+
+## Troubleshoot
+
+If a deployment fails, inspect status and use SSM without opening SSH:
+
+```bash
+aws ssm start-session --target INSTANCE_ID
+```
+
+| Message | Cause |
+| --- | --- |
+| `Required command not found: X` | Install the missing tool from [Tooling](#tooling) |
+| `AWS credentials are unavailable` | `aws sts get-caller-identity` fails; check `AWS_PROFILE` |
+| `Set X in ...` | A required deployment or runtime key is missing |
+| `Script is missing or not executable` | Run `chmod +x infra/scripts/*.sh` |
+| `Environment file not found` | The `--env-file` path is wrong |
+
+## See also
+
+- [Configuration reference](/reference/configuration/)
+- [CLI reference](/reference/cli/)
+- [Move persistence to Supabase and S3](/how-to/migrate-to-supabase/)

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: The quoptuna command-line interface — the run and optimize subcommands and their options.
+description: The quoptuna command-line interface — the run, optimize, migration, and infrastructure subcommands and their options.
 ---
 
 The `quoptuna` command is a [Typer](https://typer.tiangolo.com/) application. Invoking `quoptuna` with no subcommand is equivalent to `quoptuna run`.
@@ -110,9 +110,46 @@ quoptuna optimize --csv data.csv --target label --trials 3
 The `optimize` defaults (trials=3, sampler=random, pruner=none, max-steps=20) are tuned for a fast smoke-test run, not a production search — raise them for real optimization.
 :::
 
+## `quoptuna infra`
+
+Open the Textual console for Terraform-backed infrastructure operations:
+create, deploy, update, pause, resume, status, and destroy.
+
+```bash
+quoptuna infra --environment dev --env-file .env.deploy
+```
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--environment <e>`, `-e` | `dev` | Target environment (`dev` or `production`) |
+| `--env-file <path>` | none | Deployment `.env` file; falls back to the process environment |
+| `--terraform-dir <path>` | `infra` | Directory holding `scripts/` and `terraform/` |
+
+See [Deploy the AWS infrastructure](/how-to/deploy-infrastructure/) for
+prerequisites and what each operation does.
+
+## `quoptuna active-work`
+
+Print active optimization and analysis counts as JSON. Used by the `pause`
+operation to refuse stopping a machine while trials are still running.
+
+```bash
+quoptuna active-work
+```
+
+## `quoptuna deployment-check`
+
+Print deployment readiness checks as JSON. **Exits with code 1** when the
+deployment is unhealthy, so it can gate a deploy step in CI.
+
+```bash
+quoptuna deployment-check
+```
+
 ## See also
 
 - [REST API reference](/reference/rest-api/)
 - [Python API reference](/reference/python-api/)
 - [Model catalog](/reference/models/)
 - [Configuration reference](/reference/configuration/)
+- [Deploy the AWS infrastructure](/how-to/deploy-infrastructure/)

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -16,6 +16,7 @@ Settings can be supplied via a `.env` file or the process environment.
 | `MAX_UPLOAD_SIZE` | 100 MB | Maximum upload size |
 | `DEFAULT_N_TRIALS` | `100` | Default number of Optuna trials |
 | `DEFAULT_TIMEOUT` | `3600` s | Default run timeout |
+| `APP_ENV` | `development` | Set to `production` to enable production safety checks |
 | `CORS_ORIGINS` | — | Comma-separated list of allowed origins |
 | `APP_BASE_URL` | `http://localhost:8000` | Base URL for generated links |
 
@@ -76,6 +77,28 @@ Authentication is enforced **only when all** of these are set. When unset, `/api
 | `AUTH0_CLIENT_SECRET` | Auth0 application client secret |
 | `AUTH0_SECRET` | 64-char hex session secret (`openssl rand -hex 32`) |
 
+### Access control
+
+Authenticating is not the same as being approved. Once a session exists,
+QuOptuna additionally enforces these checks on every authenticated user:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTH_ALLOWED_EMAILS` | empty | Comma-separated approved email addresses. When empty, **any** authenticated Auth0 user is allowed |
+| `AUTH_REQUIRE_VERIFIED_EMAIL` | `true` | Reject users whose Auth0 `email_verified` is not `true` |
+
+Both failures return **403**. Matching is case-insensitive and ignores
+surrounding whitespace.
+
+:::caution
+When `APP_ENV=production` and Auth0 is configured, the server **refuses to
+start** unless `AUTH_ALLOWED_EMAILS` is non-empty. This prevents publishing a
+deployment that any Auth0 tenant user could sign in to.
+:::
+
+`/api/v1/health` stays public so load balancers and health checks work without
+a session.
+
 ## Optimizer performance toggles
 
 | Variable | Default | Purpose |
@@ -88,4 +111,5 @@ Authentication is enforced **only when all** of these are set. When unset, `/api
 
 - [CLI reference](/reference/cli/)
 - [REST API reference](/reference/rest-api/)
+- [Deploy the AWS infrastructure](/how-to/deploy-infrastructure/)
 - [Python API reference](/reference/python-api/)

--- a/docs-site/src/content/docs/reference/models.md
+++ b/docs-site/src/content/docs/reference/models.md
@@ -9,6 +9,10 @@ QuOptuna searches over quantum models (PennyLane) and classical models (scikit-l
 **Kernel** models (IQPKernelClassifier, ProjectedQuantumKernel, QuantumKitchenSinks, SeparableKernelClassifier) have no iterative training steps and are **not prunable**. **Variational** models are trained iteratively and **are prunable**. Variational quantum models are OvR-wrapped for multiclass. `TreeTensorClassifier` is a **quantum** model despite the name.
 :::
 
+:::note
+The names below are the registry keys accepted by the CLI `--models` flag and the REST API. The `/api/v1/models` endpoint returns human-readable display names (for example `Convolutional Neural Network`) for use in the UI — those are not valid registry keys.
+:::
+
 ## Quantum models (PennyLane)
 
 | Model | Type | Description | Searchable hyperparameters |
@@ -19,6 +23,7 @@ QuOptuna searches over quantum models (PennyLane) and classical models (scikit-l
 | DressedQuantumCircuitClassifier | variational | Dressed quantum circuit (classical + quantum layers) | max_vmap, batch_size, learning_rate, n_layers |
 | DressedQuantumCircuitClassifierSeparable | variational | Separable dressed quantum circuit | max_vmap, batch_size, learning_rate, n_layers |
 | QuantumBoltzmannMachineSeparable | variational | Separable quantum Boltzmann machine | max_vmap, batch_size, learning_rate, visible_qubits, temperature |
+| QuantumBoltzmannMachine | variational | Quantum Boltzmann machine | max_vmap, batch_size, learning_rate, visible_qubits, temperature |
 | TreeTensorClassifier | variational | Tree-tensor-network circuit classifier | max_vmap, batch_size, learning_rate |
 | IQPKernelClassifier | kernel | IQP-embedding quantum kernel classifier | max_vmap, repeats, C |
 | ProjectedQuantumKernel | kernel | Projected quantum kernel classifier | max_vmap, gamma_factor, C, trotter_steps, t |
@@ -26,6 +31,18 @@ QuOptuna searches over quantum models (PennyLane) and classical models (scikit-l
 | QuantumMetricLearner | variational | Quantum metric learning classifier | max_vmap, batch_size, learning_rate, n_layers |
 | SeparableVariationalClassifier | variational | Separable variational classifier | batch_size, learning_rate, encoding_layers |
 | SeparableKernelClassifier | kernel | Separable quantum kernel classifier | C, encoding_layers |
+
+## Image-shaped models
+
+These models are in the registry and selectable, but they reshape each row into
+a square 2D grid, so they only make sense for image-like datasets whose feature
+count is a perfect square. They are **not** suitable for general tabular data.
+
+| Model | Type | Description | Searchable hyperparameters |
+| --- | --- | --- | --- |
+| QuanvolutionalNeuralNetwork | variational | Quantum convolutional filters feeding a CNN | max_vmap, batch_size, learning_rate, n_qchannels, qkernel_shape, kernel_shape |
+| WeiNet | variational | Quanvolutional model using fixed classical filters (`edge_detect`, `smooth`, `sharpen`) | max_vmap, batch_size, learning_rate, filter_name |
+| ConvolutionalNeuralNetwork | classical | Classical CNN baseline | batch_size, learning_rate, kernel_shape |
 
 ## Classical models (scikit-learn)
 


### PR DESCRIPTION
Add a new AWS infrastructure deployment guide, document the `infra`, `active-work`, and `deployment-check` CLI commands, and clarify configuration and model registry behavior. Also update the landing page license text and changelog.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
