### PR TITLE
fix: Expand infrastructure and model catalog documentation, fix Optuna issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Documented the `quoptuna infra`, `active-work`, and `deployment-check` CLI commands.
+- New "Deploy the AWS infrastructure" how-to covering prerequisites, the deployment
+  file, the Textual console options, every operation and script flag, and troubleshooting.
+- Documented `AUTH_ALLOWED_EMAILS`, `AUTH_REQUIRE_VERIFIED_EMAIL`, and `APP_ENV`,
+  including the production start-up check and the public `/api/v1/health` path.
+- Added `QuantumBoltzmannMachine` to the model catalog and a new image-shaped models
+  section for `QuanvolutionalNeuralNetwork`, `WeiNet`, and `ConvolutionalNeuralNetwork`.
+
+### Changed
+- Clarified that the model catalog lists registry keys, while `/api/v1/models`
+  returns display names.
 
 ## [0.1.3]
 ### Changed

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
             { slug: "how-to/use-multiclass" },
             { slug: "how-to/generate-reports" },
             { slug: "how-to/migrate-to-supabase" },
+            { slug: "how-to/deploy-infrastructure" },
             { slug: "how-to/deploy-this-site" },
           ],
         },

--- a/docs-site/src/components/Landing.astro
+++ b/docs-site/src/components/Landing.astro
@@ -59,7 +59,7 @@ const REPO = "https://github.com/Qentora/quoptuna";
   <div class="qo-wrap">
     <div class="qo-star-inner">
       <div>
-        <div class="qo-eyebrow">Open source · MIT</div>
+        <div class="qo-eyebrow">Open source · Apache 2.0</div>
         <h2>Star it if it saved you a trial.</h2>
         <p>Stars help other researchers find QuOptuna and steer what we build next.</p>
       </div>

--- a/docs-site/src/content/docs/how-to/deploy-infrastructure.md
+++ b/docs-site/src/content/docs/how-to/deploy-infrastructure.md
@@ -1,0 +1,222 @@
+---
+title: Deploy the AWS infrastructure
+description: Prerequisites, the quoptuna infra console, and the create/deploy/pause/resume/destroy operations.
+---
+
+QuOptuna deploys as a single stoppable EC2 instance running the application
+container behind Caddy. Supabase stores application and Optuna data, and S3
+stores datasets and analysis artifacts. There is no Kubernetes cluster, load
+balancer, NAT Gateway, RDS instance, or open SSH port.
+
+Terraform lives in `infra/terraform/` (a `foundation` stack for persistent
+resources and an `application` stack for compute), and every operation is driven
+by the scripts in `infra/scripts/`.
+
+## Prerequisites
+
+### Tooling
+
+| Requirement | Notes |
+| --- | --- |
+| Terraform | `>= 1.10.0, < 2.0.0` (pinned in `versions.tf`) |
+| AWS CLI v2 | Authenticated; `aws sts get-caller-identity` must succeed |
+| Docker with Buildx | Used to build and push the immutable application image |
+| `jq` | Required by the operation scripts |
+| `git` | Used to stamp the deployed image |
+| `curl`, Python 3 | Health checks and deployment-file parsing |
+
+The scripts check for `aws`, `terraform`, `jq`, `docker`, and `git`, and fail
+with `Required command not found` if any is missing.
+
+### Accounts and resources
+
+- **AWS account** with permissions for EC2, S3, ECR, Route 53, Secrets Manager,
+  IAM, and SSM.
+- **Supabase PostgreSQL URL**. The EC2 network is dual-stack, so Supabase's
+  IPv6-only direct endpoint works. An IPv4-compatible session-pooler URL with
+  `sslmode=require` is also supported.
+- **A domain** registered anywhere and delegated to an existing Route 53 hosted
+  zone. You need the zone ID.
+- **An Auth0 application** (see [Auth0 setup](#auth0-setup) below).
+- **A globally unique S3 bucket name** for Terraform state. The scripts create
+  the bucket if it does not exist, with versioning, encryption, and public-access
+  blocking enabled.
+
+### The deployment file
+
+Copy the template and fill it in:
+
+```bash
+cp .env.deploy.example .env.deploy
+aws sts get-caller-identity
+```
+
+`infra/scripts/envfile.py` parses this file as a conservative `KEY=VALUE` subset
+— it never evaluates shell syntax. Matching variables already present in your
+process environment take precedence over the file.
+
+**Deployment keys** (control where and how infrastructure is built):
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `AWS_PROFILE` | `default` | Profile for the AWS credential chain |
+| `AWS_REGION` | `us-east-2` | Target region |
+| `TF_STATE_BUCKET` | — | Globally unique Terraform state bucket |
+| `PROJECT_NAME` | `quoptuna` | Resource name prefix |
+| `DOMAIN_NAME` | `quoptuna.example.com` | Public hostname served over HTTPS |
+| `ROUTE53_ZONE_ID` | `Z0000...` | Hosted zone for the domain |
+| `INSTANCE_TYPE` | `t3.large` | EC2 instance size |
+| `ROOT_VOLUME_SIZE` | `50` | Root EBS volume in GB |
+
+**Runtime keys** (written into the AWS Secrets Manager runtime secret):
+
+`DATABASE_URL`, `OPTUNA_DATABASE_URL`, `OPTUNA_DB_SCHEMA`, `AUTH0_DOMAIN`,
+`AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, `AUTH_ALLOWED_EMAILS`,
+`AUTH_REQUIRE_VERIFIED_EMAIL`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`GOOGLE_API_KEY`.
+
+See the [Configuration reference](/reference/configuration/) for what each
+runtime variable does.
+
+:::note
+The deployment derives `APP_ENV=production`, `APP_BASE_URL`, `CORS_ORIGINS`,
+`ARTIFACT_STORAGE=s3`, and the `S3_*` settings automatically from your domain,
+bucket, and region. Do not set them in `.env.deploy`.
+:::
+
+### Auth0 setup
+
+In the Auth0 application, set:
+
+- Allowed Callback URL: `https://YOUR_DOMAIN/auth/callback`
+- Allowed Logout URL: `https://YOUR_DOMAIN`
+- Allowed Web Origin: `https://YOUR_DOMAIN`
+
+Then open **Actions → Library → Build Custom**, create a Post-Login Action, and
+paste `infra/auth0/approved-emails.js`. Add these Action secrets:
+
+- `QUOPTUNA_CLIENT_ID` — the QuOptuna Auth0 client ID
+- `ALLOWED_EMAILS` — the same comma-separated list as `AUTH_ALLOWED_EMAILS`
+
+Deploy the Action and add it to **Actions → Flows → Login**. QuOptuna repeats the
+same allowlist and verified-email checks in the API, so removing the Action does
+not open application access.
+
+## Run from the console
+
+```bash
+uv sync
+uv run quoptuna infra --environment dev --env-file .env.deploy
+```
+
+This opens a [Textual](https://textual.textualize.io/) console with an action
+sidebar, a live status panel, and a streaming log. Secrets matching
+`password`, `secret`, `token`, `database_url`, `access_key`, or `private_key`
+are redacted from the log output.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--environment`, `-e` | `dev` | Target environment (`dev` or `production`) |
+| `--env-file` | none | Deployment `.env` file; falls back to the process environment |
+| `--terraform-dir` | `infra` | Directory holding `scripts/` and `terraform/` |
+
+Key bindings: `r` refreshes status, `q` quits. Only one operation runs at a
+time. **Pause** asks for confirmation; **Destroy** requires you to type the
+environment name exactly.
+
+## Operations
+
+| Action | What it does |
+| --- | --- |
+| **Create** | State bootstrap, persistent resources, image build, EC2, DNS, and HTTPS |
+| **Deploy** | Build and deploy a new immutable image |
+| **Update** | Apply Terraform changes and deploy the new image |
+| **Pause** | Refuse while work is active, remove DNS, and stop EC2 |
+| **Resume** | Start EC2, restore DNS, and wait for HTTPS |
+| **Status** | Report EC2 state, app health, image, and active work |
+| **Destroy** | Delete compute/network resources, preserving Supabase and AWS data |
+
+The same operations run directly as scripts:
+
+```bash
+infra/scripts/create.sh dev --env-file .env.deploy
+infra/scripts/status.sh dev --env-file .env.deploy --json
+infra/scripts/pause.sh dev --env-file .env.deploy
+infra/scripts/resume.sh dev --env-file .env.deploy
+infra/scripts/deploy.sh dev --env-file .env.deploy
+infra/scripts/update.sh dev --env-file .env.deploy
+infra/scripts/destroy.sh dev --env-file .env.deploy
+```
+
+:::caution
+The environment argument accepts only `dev` or `production`. Any other value
+fails with `Unsupported environment`.
+:::
+
+### Script options
+
+| Flag | Applies to | Purpose |
+| --- | --- | --- |
+| `--env-file PATH` | all | Deployment file to read |
+| `--json` | `status` | Emit machine-readable status (used by the console) |
+| `--plan-only` | `create`, `update` | Show the Terraform plan without applying |
+| `--force` | `pause`, `destroy` | Proceed even though work is active |
+| `--confirm-destroy` | `destroy` | Skip the interactive destroy confirmation |
+| `--delete-data` | `destroy` | Also delete the persistent AWS foundation |
+
+Use `--force` only when you intentionally accept interrupting active trials.
+
+To delete the persistent AWS foundation too:
+
+```bash
+infra/scripts/destroy.sh dev --env-file .env.deploy --delete-data
+```
+
+This requires two typed confirmations. It deletes the artifact bucket, images,
+and runtime secret. It never deletes Supabase or the Terraform-state bucket.
+
+## Check deployment health
+
+Two CLI commands report on a running deployment, both emitting JSON:
+
+```bash
+quoptuna active-work        # active optimization and analysis counts
+quoptuna deployment-check   # readiness checks; exits 1 when unhealthy
+```
+
+`pause` calls `active-work` on the instance over SSM to refuse stopping EC2
+while trials are still running. See the [CLI reference](/reference/cli/).
+
+## Cost controls
+
+- Pause EC2 whenever trials are not running.
+- The default `t3.large` uses standard CPU credits, preventing unlimited-credit
+  charges.
+- No Elastic IP is retained while paused; DNS is restored to the new address on
+  resume.
+- ECR keeps only five images.
+- Old S3 artifacts transition to Glacier Instant Retrieval.
+- Container logs rotate locally; CloudWatch log ingestion is not enabled.
+- Increase `INSTANCE_TYPE` only for trials that need more CPU or memory.
+
+## Troubleshoot
+
+If a deployment fails, inspect status and use SSM without opening SSH:
+
+```bash
+aws ssm start-session --target INSTANCE_ID
+```
+
+| Message | Cause |
+| --- | --- |
+| `Required command not found: X` | Install the missing tool from [Tooling](#tooling) |
+| `AWS credentials are unavailable` | `aws sts get-caller-identity` fails; check `AWS_PROFILE` |
+| `Set X in ...` | A required deployment or runtime key is missing |
+| `Script is missing or not executable` | Run `chmod +x infra/scripts/*.sh` |
+| `Environment file not found` | The `--env-file` path is wrong |
+
+## See also
+
+- [Configuration reference](/reference/configuration/)
+- [CLI reference](/reference/cli/)
+- [Move persistence to Supabase and S3](/how-to/migrate-to-supabase/)

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: The quoptuna command-line interface — the run and optimize subcommands and their options.
+description: The quoptuna command-line interface — the run, optimize, migration, and infrastructure subcommands and their options.
 ---
 
 The `quoptuna` command is a [Typer](https://typer.tiangolo.com/) application. Invoking `quoptuna` with no subcommand is equivalent to `quoptuna run`.
@@ -110,9 +110,46 @@ quoptuna optimize --csv data.csv --target label --trials 3
 The `optimize` defaults (trials=3, sampler=random, pruner=none, max-steps=20) are tuned for a fast smoke-test run, not a production search — raise them for real optimization.
 :::
 
+## `quoptuna infra`
+
+Open the Textual console for Terraform-backed infrastructure operations:
+create, deploy, update, pause, resume, status, and destroy.
+
+```bash
+quoptuna infra --environment dev --env-file .env.deploy
+```
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--environment <e>`, `-e` | `dev` | Target environment (`dev` or `production`) |
+| `--env-file <path>` | none | Deployment `.env` file; falls back to the process environment |
+| `--terraform-dir <path>` | `infra` | Directory holding `scripts/` and `terraform/` |
+
+See [Deploy the AWS infrastructure](/how-to/deploy-infrastructure/) for
+prerequisites and what each operation does.
+
+## `quoptuna active-work`
+
+Print active optimization and analysis counts as JSON. Used by the `pause`
+operation to refuse stopping a machine while trials are still running.
+
+```bash
+quoptuna active-work
+```
+
+## `quoptuna deployment-check`
+
+Print deployment readiness checks as JSON. **Exits with code 1** when the
+deployment is unhealthy, so it can gate a deploy step in CI.
+
+```bash
+quoptuna deployment-check
+```
+
 ## See also
 
 - [REST API reference](/reference/rest-api/)
 - [Python API reference](/reference/python-api/)
 - [Model catalog](/reference/models/)
 - [Configuration reference](/reference/configuration/)
+- [Deploy the AWS infrastructure](/how-to/deploy-infrastructure/)

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -16,6 +16,7 @@ Settings can be supplied via a `.env` file or the process environment.
 | `MAX_UPLOAD_SIZE` | 100 MB | Maximum upload size |
 | `DEFAULT_N_TRIALS` | `100` | Default number of Optuna trials |
 | `DEFAULT_TIMEOUT` | `3600` s | Default run timeout |
+| `APP_ENV` | `development` | Set to `production` to enable production safety checks |
 | `CORS_ORIGINS` | — | Comma-separated list of allowed origins |
 | `APP_BASE_URL` | `http://localhost:8000` | Base URL for generated links |
 
@@ -76,6 +77,28 @@ Authentication is enforced **only when all** of these are set. When unset, `/api
 | `AUTH0_CLIENT_SECRET` | Auth0 application client secret |
 | `AUTH0_SECRET` | 64-char hex session secret (`openssl rand -hex 32`) |
 
+### Access control
+
+Authenticating is not the same as being approved. Once a session exists,
+QuOptuna additionally enforces these checks on every authenticated user:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTH_ALLOWED_EMAILS` | empty | Comma-separated approved email addresses. When empty, **any** authenticated Auth0 user is allowed |
+| `AUTH_REQUIRE_VERIFIED_EMAIL` | `true` | Reject users whose Auth0 `email_verified` is not `true` |
+
+Both failures return **403**. Matching is case-insensitive and ignores
+surrounding whitespace.
+
+:::caution
+When `APP_ENV=production` and Auth0 is configured, the server **refuses to
+start** unless `AUTH_ALLOWED_EMAILS` is non-empty. This prevents publishing a
+deployment that any Auth0 tenant user could sign in to.
+:::
+
+`/api/v1/health` stays public so load balancers and health checks work without
+a session.
+
 ## Optimizer performance toggles
 
 | Variable | Default | Purpose |
@@ -88,4 +111,5 @@ Authentication is enforced **only when all** of these are set. When unset, `/api
 
 - [CLI reference](/reference/cli/)
 - [REST API reference](/reference/rest-api/)
+- [Deploy the AWS infrastructure](/how-to/deploy-infrastructure/)
 - [Python API reference](/reference/python-api/)

--- a/docs-site/src/content/docs/reference/models.md
+++ b/docs-site/src/content/docs/reference/models.md
@@ -9,6 +9,10 @@ QuOptuna searches over quantum models (PennyLane) and classical models (scikit-l
 **Kernel** models (IQPKernelClassifier, ProjectedQuantumKernel, QuantumKitchenSinks, SeparableKernelClassifier) have no iterative training steps and are **not prunable**. **Variational** models are trained iteratively and **are prunable**. Variational quantum models are OvR-wrapped for multiclass. `TreeTensorClassifier` is a **quantum** model despite the name.
 :::
 
+:::note
+The names below are the registry keys accepted by the CLI `--models` flag and the REST API. The `/api/v1/models` endpoint returns human-readable display names (for example `Convolutional Neural Network`) for use in the UI — those are not valid registry keys.
+:::
+
 ## Quantum models (PennyLane)
 
 | Model | Type | Description | Searchable hyperparameters |
@@ -19,6 +23,7 @@ QuOptuna searches over quantum models (PennyLane) and classical models (scikit-l
 | DressedQuantumCircuitClassifier | variational | Dressed quantum circuit (classical + quantum layers) | max_vmap, batch_size, learning_rate, n_layers |
 | DressedQuantumCircuitClassifierSeparable | variational | Separable dressed quantum circuit | max_vmap, batch_size, learning_rate, n_layers |
 | QuantumBoltzmannMachineSeparable | variational | Separable quantum Boltzmann machine | max_vmap, batch_size, learning_rate, visible_qubits, temperature |
+| QuantumBoltzmannMachine | variational | Quantum Boltzmann machine | max_vmap, batch_size, learning_rate, visible_qubits, temperature |
 | TreeTensorClassifier | variational | Tree-tensor-network circuit classifier | max_vmap, batch_size, learning_rate |
 | IQPKernelClassifier | kernel | IQP-embedding quantum kernel classifier | max_vmap, repeats, C |
 | ProjectedQuantumKernel | kernel | Projected quantum kernel classifier | max_vmap, gamma_factor, C, trotter_steps, t |
@@ -26,6 +31,18 @@ QuOptuna searches over quantum models (PennyLane) and classical models (scikit-l
 | QuantumMetricLearner | variational | Quantum metric learning classifier | max_vmap, batch_size, learning_rate, n_layers |
 | SeparableVariationalClassifier | variational | Separable variational classifier | batch_size, learning_rate, encoding_layers |
 | SeparableKernelClassifier | kernel | Separable quantum kernel classifier | C, encoding_layers |
+
+## Image-shaped models
+
+These models are in the registry and selectable, but they reshape each row into
+a square 2D grid, so they only make sense for image-like datasets whose feature
+count is a perfect square. They are **not** suitable for general tabular data.
+
+| Model | Type | Description | Searchable hyperparameters |
+| --- | --- | --- | --- |
+| QuanvolutionalNeuralNetwork | variational | Quantum convolutional filters feeding a CNN | max_vmap, batch_size, learning_rate, n_qchannels, qkernel_shape, kernel_shape |
+| WeiNet | variational | Quanvolutional model using fixed classical filters (`edge_detect`, `smooth`, `sharpen`) | max_vmap, batch_size, learning_rate, filter_name |
+| ConvolutionalNeuralNetwork | classical | Classical CNN baseline | batch_size, learning_rate, kernel_shape |
 
 ## Classical models (scikit-learn)
 

--- a/frontend/app/runs/page.tsx
+++ b/frontend/app/runs/page.tsx
@@ -2,6 +2,16 @@
 
 import { initialWorkflowData } from '@/components/optimizer/types';
 import type { WorkflowData } from '@/components/optimizer/types';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -54,6 +64,7 @@ export default function RunsPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [openingId, setOpeningId] = useState<string | null>(null);
+  const [pendingRemoval, setPendingRemoval] = useState<PastRun | null>(null);
 
   const { data: runs = [], isLoading } = useQuery({
     queryKey: ['optimization-runs'],
@@ -167,6 +178,8 @@ export default function RunsPage() {
       await queryClient.invalidateQueries({ queryKey: ['optimization-runs'] });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Could not delete run');
+    } finally {
+      setPendingRemoval(null);
     }
   };
 
@@ -239,7 +252,7 @@ export default function RunsPage() {
                       type="button"
                       size="sm"
                       variant="outline"
-                      onClick={() => void removeRun(run)}
+                      onClick={() => setPendingRemoval(run)}
                     >
                       <CircleSlash className="h-4 w-4" />
                       Cancel
@@ -320,7 +333,7 @@ export default function RunsPage() {
                         size="sm"
                         variant="ghost"
                         aria-label="Delete run"
-                        onClick={() => void removeRun(run)}
+                        onClick={() => setPendingRemoval(run)}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
@@ -332,6 +345,41 @@ export default function RunsPage() {
           </Table>
         )}
       </section>
+
+      <AlertDialog
+        open={pendingRemoval !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemoval(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingRemoval && ACTIVE_STATUSES.includes(pendingRemoval.status)
+                ? 'Cancel this optimization?'
+                : 'Delete this run?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingRemoval && ACTIVE_STATUSES.includes(pendingRemoval.status)
+                ? `This will stop "${pendingRemoval.study_name ?? pendingRemoval.id}" and its trials so far cannot be resumed.`
+                : `This will permanently delete "${pendingRemoval?.study_name ?? pendingRemoval?.id}" and its trial history. This action cannot be undone.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep run</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (pendingRemoval) void removeRun(pendingRemoval);
+              }}
+            >
+              {pendingRemoval && ACTIVE_STATUSES.includes(pendingRemoval.status)
+                ? 'Cancel optimization'
+                : 'Delete run'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageShell>
   );
 }

--- a/frontend/components/ui/alert-dialog.tsx
+++ b/frontend/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { Button, buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'fixed inset-0 isolate z-50 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-xs/relaxed text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('font-heading text-sm font-medium', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-xs/relaxed text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, 'variant'>) {
+  return (
+    <AlertDialogPrimitive.Action className={cn(buttonVariants({ variant }), className)} {...props} />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "auth0-server-python>=1.0.0b1,<2",
     "sqlmodel>=0.0.22,<0.1.0",
     "psycopg[binary]>=3.2.0,<4.0.0",
+    "psycopg2-binary>=2.9.0,<3.0.0",
     "boto3>=1.35.0,<2.0.0",
     "textual>=0.70.0,<1.0.0",
 ]

--- a/src/quoptuna/backend/tuners/optimizer.py
+++ b/src/quoptuna/backend/tuners/optimizer.py
@@ -17,7 +17,7 @@ from quoptuna.backend.utils.data_utils.data import (
     preprocess_data,
     stratified_train_test_split,
 )
-from quoptuna.backend.utils.storage import ensure_db_dir, optuna_db_path
+from quoptuna.backend.utils.storage import ensure_db_dir, optuna_db_path, optuna_storage_url
 from quoptuna.backend.xai.fairness import FAIRNESS_METRICS, WORST_DISPARITY, compute_disparity
 
 logging.getLogger().setLevel(logging.INFO)
@@ -182,7 +182,7 @@ class Optimizer:
         self.val_x = self.val_y = None
         ensure_db_dir()
         self.data_path = str(optuna_db_path(self.db_name))
-        self.storage_location = f"sqlite:///{self.data_path}"
+        self.storage_location = optuna_storage_url(self.db_name)
         self.study_name = study_name
         self.study = None
         self.model_types = model_types or DEFAULT_MODEL_TYPES

--- a/src/quoptuna/backend/utils/storage.py
+++ b/src/quoptuna/backend/utils/storage.py
@@ -52,8 +52,15 @@ def optuna_storage_url(db_name: str) -> str:
         url = settings.DATABASE_URL
     else:
         return f"sqlite:///{optuna_db_path(db_name)}"
-    if url.startswith("postgresql://"):
-        url = url.replace("postgresql://", "postgresql+psycopg://", 1)
+    # Optuna's RDB backend compares its native TrialValueType/StudyDirection
+    # Postgres enums against a ``::VARCHAR``-cast parameter in generated SQL
+    # (e.g. the ORDER BY CASE in get_best_trial()). psycopg 3 surfaces this as
+    # "operator does not exist: trialvaluetype = character varying"; psycopg2
+    # does not hit the same adaptation path, so Optuna storage always uses it
+    # regardless of which driver the rest of the app uses for DATABASE_URL.
+    if url.startswith(("postgresql://", "postgresql+psycopg://")):
+        url = url.split("://", 1)[1]
+        url = f"postgresql+psycopg2://{url}"
     parsed = urlparse(url)
     options = quote(f"-csearch_path={settings.OPTUNA_DB_SCHEMA}", safe="")
     separator = "&" if parsed.query else ""

--- a/src/quoptuna/server/core/auth.py
+++ b/src/quoptuna/server/core/auth.py
@@ -121,7 +121,11 @@ async def redirect_unauthenticated_requests(
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
     """Redirect every unauthenticated request into the Auth0 login flow."""
-    if not settings.AUTH_ENABLED or _is_public_auth_path(request.url.path):
+    if (
+        request.method == "OPTIONS"
+        or not settings.AUTH_ENABLED
+        or _is_public_auth_path(request.url.path)
+    ):
         return await call_next(request)
 
     if await get_current_user(request) is not None:

--- a/src/quoptuna/server/services/workflow_service.py
+++ b/src/quoptuna/server/services/workflow_service.py
@@ -824,5 +824,5 @@ class WorkflowExecutor:
             return final_result
 
         except Exception as e:
-            logger.error(f"Workflow execution failed: {e!s}")
+            logger.exception(f"Workflow execution failed: {e!s}")
             raise WorkflowExecutionError(f"Execution failed: {e!s}") from e

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1478,6 +1479,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030 },
     { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603 },
     { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525 },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366 },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873 },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816 },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445 },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810 },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443 },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039 },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613 },
 ]
 
 [[package]]
@@ -1616,6 +1625,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947 },
     { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569 },
     { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997 },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262 },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036 },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295 },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987 },
     { url = "https://files.pythonhosted.org/packages/e9/eb/5fcbbbf9a0e2c3a35effb88831a483345326bbc3a030a3b5b69aee647f84/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232", size = 59532 },
     { url = "https://files.pythonhosted.org/packages/c3/9b/e17104555bb4db148fd52327feea1e96be4b88e8e008b029002c281a21ab/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a", size = 57420 },
     { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892 },
@@ -2863,6 +2876,36 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338 },
+    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407 },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425 },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709 },
+    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779 },
+    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308 },
+    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405 },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187 },
+    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716 },
+    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237 },
+    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036 },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459 },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936 },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676 },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917 },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843 },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556 },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714 },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154 },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882 },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298 },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230 },
+]
+
+[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2968,6 +3011,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823 },
     { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919 },
     { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604 },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589 },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552 },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984 },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417 },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527 },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024 },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696 },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590 },
     { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782 },
     { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146 },
     { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492 },
@@ -3249,6 +3300,7 @@ dependencies = [
     { name = "pmlb" },
     { name = "pre-commit" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytest" },
@@ -3297,6 +3349,7 @@ requires-dist = [
     { name = "pmlb", specifier = ">=1.0.1.post3" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0,<4.0.0" },
+    { name = "psycopg2-binary", specifier = ">=2.9.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.3.4,<9.0.0" },


### PR DESCRIPTION
This pull request introduces several documentation improvements and a user experience enhancement in the frontend. The most important changes are:

**Documentation Additions and Improvements:**

* Added a comprehensive how-to guide for deploying the AWS infrastructure, including prerequisites, deployment file details, console usage, available operations, script options, troubleshooting, and cost controls (`docs-site/src/content/docs/how-to/deploy-infrastructure.md`).
* Documented the `quoptuna infra`, `active-work`, and `deployment-check` CLI commands in the CLI reference and changelog, and linked to the new infrastructure deployment guide. [[1]](diffhunk://#diff-0710ac3b76761967713ea0f18ddcabb3e44fbf49d688291d050aeda624cde8dfL3-R3) [[2]](diffhunk://#diff-0710ac3b76761967713ea0f18ddcabb3e44fbf49d688291d050aeda624cde8dfR113-R155) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R18)
* Clarified the distinction between model registry keys and display names in the model catalog, and added new models: `QuantumBoltzmannMachine` and a section for image-shaped models (`QuanvolutionalNeuralNetwork`, `WeiNet`, `ConvolutionalNeuralNetwork`). [[1]](diffhunk://#diff-38600d61aad919d753b4ff52cde86bb5d8c203433b7ed7e935610ec5599a4c44R12-R15) [[2]](diffhunk://#diff-38600d61aad919d753b4ff52cde86bb5d8c203433b7ed7e935610ec5599a4c44R26) [[3]](diffhunk://#diff-38600d61aad919d753b4ff52cde86bb5d8c203433b7ed7e935610ec5599a4c44R35-R46) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R18)
* Improved configuration documentation by adding details for `AUTH_ALLOWED_EMAILS`, `AUTH_REQUIRE_VERIFIED_EMAIL`, and `APP_ENV`, including production safety checks and the public health path. [[1]](diffhunk://#diff-597c62385c64a10299df818a1c87c70fab8bfc0551e45e77435fc0efa5eb6b76R19) [[2]](diffhunk://#diff-597c62385c64a10299df818a1c87c70fab8bfc0551e45e77435fc0efa5eb6b76R80-R101) [[3]](diffhunk://#diff-597c62385c64a10299df818a1c87c70fab8bfc0551e45e77435fc0efa5eb6b76R114) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R18)
* Updated the open source license mention from MIT to Apache 2.0 in the landing page.

**Frontend User Experience:**

* Added a confirmation dialog before deleting a run in the `RunsPage` to prevent accidental deletions. The dialog appears when the user clicks delete or cancel, and only proceeds with deletion upon confirmation. [[1]](diffhunk://#diff-706f690c71cff36f2fc721578a0bec3cca2ba61b0cf2bfdb57a3705057fcc3f9R5-R14) [[2]](diffhunk://#diff-706f690c71cff36f2fc721578a0bec3cca2ba61b0cf2bfdb57a3705057fcc3f9R67) [[3]](diffhunk://#diff-706f690c71cff36f2fc721578a0bec3cca2ba61b0cf2bfdb57a3705057fcc3f9R181-R182) [[4]](diffhunk://#diff-706f690c71cff36f2fc721578a0bec3cca2ba61b0cf2bfdb57a3705057fcc3f9L242-R255) [[5]](diffhunk://#diff-706f690c71cff36f2fc721578a0bec3cca2ba61b0cf2bfdb57a3705057fcc3f9L323-R336)

Other minor changes include updating the sidebar navigation to include the new infrastructure deployment guide.